### PR TITLE
feat: Grouping Segments Semantically

### DIFF
--- a/motion-pipeline/motion_extraction/audio_analysis/__init__.py
+++ b/motion-pipeline/motion_extraction/audio_analysis/__init__.py
@@ -3,19 +3,19 @@ import dataclasses_json as dcj
 import typing as t
 import numpy as np
 from pathlib import Path
-from .audio_tools import calculate_8beat_segments_with_midpoints, load_audio, save_audio_from_video
+from .audio_tools import calculate_8beat_segments_with_midpoints, load_audio, MusicPhrase
 from .tempo_analysis import TempoInfo, calculate_tempo_info
 from .similarity_analysis import calculate_cross_similarity, compute_segment_groupings
 from ..dancetree import DanceTree, DanceTreeNode
 
 @dc.dataclass
 class AudioAnalysisResult(dcj.DataClassJsonMixin):
-        duration: float
-        sample_rate: int
-        tempo_info: TempoInfo
-        eight_beat_segments: t.List[t.List[float]]
-        segment_groupings: t.List[int]
-        cross_similarity: t.List[t.List[float]]
+    duration: float
+    sample_rate: int
+    tempo_info: TempoInfo
+    musical_phrases: t.List[MusicPhrase]
+    phrase_groupings: t.List[t.List[int]]
+    cross_similarity: t.List[t.List[float]]
 
 def analyze_audio_file(filepath: Path) -> AudioAnalysisResult:
     # Load the audio file
@@ -31,61 +31,68 @@ def analyze_audio(audio_array: np.ndarray, sample_rate: int) -> AudioAnalysisRes
 
     # Create 8-bar segments.
     eight_beat_segments_with_midpoints = list(calculate_8beat_segments_with_midpoints(tempo_info.bpm, tempo_info.starting_beat_timestamp, duration))
-    eight_beat_segments = [(times[0], times[-1]) for times in eight_beat_segments_with_midpoints]
+    eight_beat_segments_noendpoints = [
+        (times.start_time, times.end_time) 
+        for times in eight_beat_segments_with_midpoints
+    ]
 
     # Compute similarity of 8-bar segments, then group them into larger components.
-    cross_similarity  = calculate_cross_similarity(audio_array, sample_rate, eight_beat_segments)
+    cross_similarity  = calculate_cross_similarity(audio_array, sample_rate, eight_beat_segments_noendpoints)
     segment_groupings = compute_segment_groupings(cross_similarity)
     
     return AudioAnalysisResult(
         duration=duration,
         sample_rate=sample_rate,
         tempo_info=tempo_info,
-        eight_beat_segments=eight_beat_segments_with_midpoints,
-        segment_groupings=segment_groupings,
+        musical_phrases=eight_beat_segments_with_midpoints,
+        phrase_groupings=segment_groupings,
         cross_similarity=cross_similarity.tolist()
     )
 
 def create_dance_tree_from_audioanalysis(tree_name: str, clip_relativepath: str, analysis: AudioAnalysisResult) -> DanceTree:
-    return DanceTree(
-         tree_name=tree_name,
-         clip_relativepath=clip_relativepath,
-         bpm=analysis.tempo_info.bpm,
-         first_beat=analysis.tempo_info.starting_beat_timestamp,
-        root=DanceTreeNode(
-            id='wholesong',
+
+    # Create tree & root node
+    tree = DanceTree(
+        tree_name=tree_name,
+        clip_relativepath=clip_relativepath,
+        bpm=analysis.tempo_info.bpm,
+        first_beat=analysis.tempo_info.starting_beat_timestamp,
+        root=DanceTreeNode(id='wholesong',
             start_time=0,
             end_time=analysis.duration,
-            children=[
-                 DanceTreeNode(
-                id=f"grouping{group_i}",
-                start_time=analysis.eight_beat_segments[grouping[0]][0]],
-                end_time=analysis.eight_beat_segments[grouping[-1]][-1],
-                metrics={},
-                events={},     
-                 children=
-                    [
-                        DanceTreeNode(
-                        id=f"phrase{seg_i}",
-                        start_time=segment_timestamps[0],
-                        end_time=segment_timestamps[-1],
-                        metrics={
-                            f'similarity-to-phrase{j}': analysis.cross_similarity[seg_i][j]
-                            for j in range(len(analysis.cross_similarity[seg_i]))
-                        },
-                        events={},
-                        children=[
-                            DanceTreeNode(
-                                id=f"phrase{seg_i}-bar{bar_i}",
-                                start_time=bar_start,
-                                end_time=bar_end,
-                            )
-                            for bar_i, (bar_start, bar_end) in enumerate(zip(segment_timestamps[:-1], segment_timestamps[1:]))
-                        ],
-                        ) 
-                        for seg_i, segment_timestamps in enumerate(analysis.eight_beat_segments[grouping[0]:grouping[-1]+1])
-                    ])
-                for group_i, grouping in enumerate(analysis.segment_groupings)
-            ]
+            children=[]
         )
     )
+
+    for grouping_i, grouping in enumerate(analysis.phrase_groupings):
+        group_node = DanceTreeNode(
+            id=f"group{grouping_i}",
+            start_time=analysis.musical_phrases[grouping[0]].start_time,
+            end_time=analysis.musical_phrases[grouping[-1]].end_time,
+            metrics={},
+            events={},     
+            children=[]
+        )
+        tree.root.children.append(group_node)
+
+        # Don't add a group if it's just one segment.
+        if len(grouping) == 1:
+            continue
+
+        for segment_index in grouping:
+            musical_phrase = analysis.musical_phrases[segment_index]
+            seg_node = DanceTreeNode(
+                id=f"phrase{segment_index}",
+                start_time=musical_phrase.start_time,
+                end_time=musical_phrase.end_time,
+                metrics={
+                    f'similarity-to-phrase{j}': analysis.cross_similarity[segment_index][j]
+                    for j in range(len(analysis.cross_similarity[segment_index]))
+                },
+                events={},     
+                children=[]
+            )
+            group_node.children.append(seg_node)
+
+    return tree
+        

--- a/motion-pipeline/motion_extraction/audio_analysis/similarity_analysis.py
+++ b/motion-pipeline/motion_extraction/audio_analysis/similarity_analysis.py
@@ -58,6 +58,54 @@ def calculate_cross_similarity(y: np.ndarray, sr: float, segment_times: t.List[t
 
     return cross_similarity
 
+def compute_segment_groupings(similarity_matrix: t.List[t.List[float]]) -> t.List[t.List[int]]:
+    """
+    Calculates a grouping that places similar contiguous segments into groups. 
+
+    Parameters:
+    similarity_matrix (List[List[float]]): A 2D matrix of the cross similarity ratings between segments. 
+
+    Returns:
+    A list of grouped segments, represented by their indices, in increasing order.
+
+    Example:
+    groupings = compute_segment_groupings([
+        [1.00, 0.90, 0.50,  0.40],
+        [0.90, 1.00, 0.60,  0.35],
+        [0.50, 0.60, 1.00,  0.85],
+        [0.40, 0.35, 0.85,  1.00]
+    ])
+    # groupings == [[0, 1], [2, 3]]
+    """
+
+    similarity_matrix = np.array(similarity_matrix)
+    
+    GROUPING_THRESHOLD = 0.60
+    if len(similarity_matrix) == 0:
+        return 0
+    
+    groupings = []
+    current_group = [0]
+
+    for i in range(1, len(similarity_matrix)):
+        for j in range(i+1, len(similarity_matrix)):
+            mean_current_group_similarity = np.mean([
+                similarity_matrix[current_group_index][i]
+                for current_group_index in current_group
+            ])
+            if mean_current_group_similarity > GROUPING_THRESHOLD:
+                current_group.append(i)
+                continue
+            else:
+                groupings.append(current_group)
+                current_group = [j]
+                break
+            
+    if len(current_group) > 0:
+        groupings.append(current_group)
+
+    return groupings
+
 def plot_cross_similarity(
     cross_similarity: t.Union[np.ndarray, t.Sequence[t.Sequence[float]]], 
     ax=None

--- a/motion-pipeline/motion_extraction/audio_analysis/similarity_analysis.py
+++ b/motion-pipeline/motion_extraction/audio_analysis/similarity_analysis.py
@@ -87,23 +87,19 @@ def compute_segment_groupings(similarity_matrix: t.List[t.List[float]]) -> t.Lis
     groupings = []
     current_group = [0]
 
-    for i in range(1, len(similarity_matrix)):
-        for j in range(i+1, len(similarity_matrix)):
-            mean_current_group_similarity = np.mean([
-                similarity_matrix[current_group_index][i]
-                for current_group_index in current_group
-            ])
-            if mean_current_group_similarity > GROUPING_THRESHOLD:
-                current_group.append(i)
-                continue
-            else:
-                groupings.append(current_group)
-                current_group = [j]
-                break
+    for segment_index in range(1, len(similarity_matrix)):
+        segment_crosssimilarities = similarity_matrix[segment_index]
+        similarities_to_current_group = segment_crosssimilarities[current_group]
+        mean_current_group_similarity = np.mean(similarities_to_current_group)
+        if mean_current_group_similarity > GROUPING_THRESHOLD:
+            current_group.append(segment_index)
+            continue
+        else:
+            groupings.append(current_group)
+            current_group = [segment_index]
+            continue
             
-    if len(current_group) > 0:
-        groupings.append(current_group)
-
+    groupings.append(current_group)
     return groupings
 
 def plot_cross_similarity(

--- a/motion-pipeline/motion_extraction/complexity_analysis/add_complexity_to_dancetree.py
+++ b/motion-pipeline/motion_extraction/complexity_analysis/add_complexity_to_dancetree.py
@@ -87,10 +87,11 @@ def add_complexities_to_dancetrees(
             print(' - no database entry found!')
             continue
 
-        tree = None
-        with dance_tree_file.open('r+') as f:
-            tree = DanceTree.from_dict(json.load(f))    
-
+        
+        tree_text = dance_tree_file.read_text()
+        tree = json.loads(tree_text)
+        tree = DanceTree.from_dict(tree)
+        
         fps = matching_db_entry['fps']
         tree = add_complexity_to_dancetree(tree, complexity, fps)
             

--- a/motion-pipeline/motion_extraction/stepone_get_holistic_data.py
+++ b/motion-pipeline/motion_extraction/stepone_get_holistic_data.py
@@ -295,16 +295,6 @@ def process_video(
     rewrite_existing: bool = False,
     print_progress_context: t.Callable[[],str] = lambda: '',
 ):
-
-    # Reset graph for this new file
-    holistic_solution.reset()
-
-    # Get video width / height
-    cap = cv2.VideoCapture(str(video_path))
-    video_width = cap.get(cv2.CAP_PROP_FRAME_WIDTH)
-    video_height = cap.get(cv2.CAP_PROP_FRAME_HEIGHT)
-    cap.release()
-
     video_file_relative = video_path.relative_to(parent_folder)
     video_file_relative_stem = video_file_relative.with_suffix('')
 
@@ -321,6 +311,16 @@ def process_video(
        not rewrite_existing:
         print(f'{print_progress_context()}Skipping (already exists): {video_file_relative}')
         return
+
+    # Reset graph for this new file
+    holistic_solution.reset()
+
+    # Get video width / height
+    cap = cv2.VideoCapture(str(video_path))
+    video_width = cap.get(cv2.CAP_PROP_FRAME_WIDTH)
+    video_height = cap.get(cv2.CAP_PROP_FRAME_HEIGHT)
+    cap.release()
+
     
     header_row = construct_header_row()
     pose2d_header_row = construct_pose2d_header_row()
@@ -440,8 +440,6 @@ def compute_holistic_data(
         model_complexity=model_complexity,
         enable_segmentation=False
     )
-
-    
 
     if not output_folder.exists():
         output_folder.mkdir(parents=True)

--- a/svelte-web-frontend/src/lib/DanceTreeVisual.svelte
+++ b/svelte-web-frontend/src/lib/DanceTreeVisual.svelte
@@ -31,6 +31,8 @@ function barClicked () {
        class:button={enableClick} 
        class:active={showProgress}
        on:click={barClicked}
+       role="menuitem"
+       tabindex="0"
     >   
         {#if $debugMode}
         <span class="complexity">
@@ -119,7 +121,6 @@ function barClicked () {
         display: flex;
         flex-direction: column;
         align-items: stretch;
-        justify-content: center;
         gap: 0.25em;
         flex-basis: 0;
         flex-grow: var(--node-duration);


### PR DESCRIPTION
Implements an improvement in the dance tree generation algorithm, updating it to group musical phrases together based on the cross-similarity between different segments.

**Before**
![before](https://github.com/j55blanchet/dance-teacher-xr-unity/assets/4062772/074369a8-b155-466e-b82c-874596779dd3)

**After**
![after](https://github.com/j55blanchet/dance-teacher-xr-unity/assets/4062772/c4e40ade-cf82-47e3-ae04-c02eec06320f)

The current algorithm implementation is simple and greedy. Given a matrix of similarities between different segments, like this:
![Tinashe--Party-Favors-ft-Young-Thug--Cheshir-Choreo-Class -Justjerk-Dance-Academy-trimmed copy](https://github.com/j55blanchet/dance-teacher-xr-unity/assets/4062772/6400bdd8-4acd-49cc-bcea-c07e3d9cbed4)

The algorithm sequentially parses the segments one-at-a-time, keeping track of the current grouping. The newly considered segment is compared to the current group, and a mean similarity is calculated. If this value is greater than a similarity threshold, the new segment is added to the current group; otherwise, the current group is finalized and the new segment starts a new current group. The intention behind grouping segments together like this is to form clusters of related segments, as shown in this plot (however, no overlaps are performed with the current implementation).
![Tinashe--Party-Favors-ft-Young-Thug--Cheshir-Choreo-Class -Justjerk-Dance-Academy-trimmed](https://github.com/j55blanchet/dance-teacher-xr-unity/assets/4062772/f16edea1-d319-4751-8307-d6b9701bbc3c)

There is plenty of room for improvement in future iterations (for a more semantic grouping), but this is a good place to start!
