### PR TITLE
Fix: Implementing consistent navbar

### DIFF
--- a/svelte-web-frontend/src/lib/elements/NavBar.svelte
+++ b/svelte-web-frontend/src/lib/elements/NavBar.svelte
@@ -20,34 +20,35 @@ export let navbarProps = writable<NavBarProps>({
     collapsed: true,
     pageTitle: 'LearnThatDance',
 });
-
-</script>
-<script lang="ts">
-
 </script>
 
 <nav class:collapsed={$navbarProps.collapsed}>
+    <!-- Container for left-aligned content -->
     {#if $navbarProps.back}
-    <a class="button" href={$navbarProps.back.url}>&lt; {$navbarProps.back.title}</a>
+        <a class="button" href={$navbarProps.back.url}>&lt; {$navbarProps.back.title}</a>
     {:else}
-    <div></div>
+        <div></div>
     {/if}
+
+    <!-- Container for centered content-->
     <h1>{$navbarProps.pageTitle}</h1>
+
+    <!-- Container for right-aligned content-->
     <div></div>
 </nav>
 
 <style lang="scss">
 
 nav {
-	padding: 0 0.5em;
+    padding: 0 0.5em;
     box-sizing: border-box;
     height: var(--navbar_height);
-	display: flex;
-	flex-direction: row;
-	justify-content: space-between;
-	align-items: center;
-	background: rgba(0, 0, 0, .2);
-	width: 100%;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+    background: rgba(0, 0, 0, .2);
+    width: 100%;
     overflow: hidden;
     transition: height 0.2s ease-in-out;
 }
@@ -57,9 +58,9 @@ nav.collapsed {
 }
 
 nav h1 {
-	margin: 0;
-	padding: 0;
-	font-size: 2rem;
+    margin: 0;
+    padding: 0;
+    font-size: 2rem;
 }
 
 

--- a/svelte-web-frontend/src/lib/elements/NavBar.svelte
+++ b/svelte-web-frontend/src/lib/elements/NavBar.svelte
@@ -1,0 +1,66 @@
+<script context="module" lang="ts">
+// 
+// Code in the script-level module is shared among all instances of NavBar 
+// (which there should only be one of). It also gives child pages a way to 
+// alter properties of the NavBar (such as the page title). They can do that
+// by importing these writable stores (which are singletons, at the module level),
+// and writing to them as needed (likely during `onMount`).
+import { writable } from "svelte/store";
+
+export type NavBarProps = {
+    collapsed: boolean;
+    pageTitle: string;
+    back?: {
+        url: string;
+        title: string;
+    };
+}
+
+export let navbarProps = writable<NavBarProps>({
+    collapsed: true,
+    pageTitle: 'LearnThatDance',
+});
+
+</script>
+<script lang="ts">
+
+</script>
+
+<nav class:collapsed={$navbarProps.collapsed}>
+    {#if $navbarProps.back}
+    <a class="button" href={$navbarProps.back.url}>&lt; {$navbarProps.back.title}</a>
+    {:else}
+    <div></div>
+    {/if}
+    <h1>{$navbarProps.pageTitle}</h1>
+    <div></div>
+</nav>
+
+<style lang="scss">
+
+nav {
+	padding: 0 0.5em;
+    box-sizing: border-box;
+    height: var(--navbar_height);
+	display: flex;
+	flex-direction: row;
+	justify-content: space-between;
+	align-items: center;
+	background: rgba(0, 0, 0, .2);
+	width: 100%;
+    overflow: hidden;
+    transition: height 0.2s ease-in-out;
+}
+
+nav.collapsed {
+    height: 0;
+}
+
+nav h1 {
+	margin: 0;
+	padding: 0;
+	font-size: 2rem;
+}
+
+
+</style>

--- a/svelte-web-frontend/src/lib/elements/SketchButton.svelte
+++ b/svelte-web-frontend/src/lib/elements/SketchButton.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
+export let disabled: boolean = false
 </script>
 
-<button on:click>
+<button on:click disabled={disabled}>
     <span>
         <slot></slot>
     </span>

--- a/svelte-web-frontend/src/lib/elements/TerminalFeedbackDialog.svelte
+++ b/svelte-web-frontend/src/lib/elements/TerminalFeedbackDialog.svelte
@@ -80,8 +80,8 @@ onMount(() => {
     {#if $debugMode && feedback?.debugJson}
     <pre class="microlight">{JSON.stringify(feedback.debugJson, replaceJSONForStringifyDisplay, 2)}</pre>
     {/if}
-    <button class="outlined" on:click={primaryButtonClicked}>{primaryButtonTitle}</button>
-    <button class="outlined thin" on:click={secondaryButtonClicked}>{secondaryButtonTitle}</button>
+    <button class="button outlined thick primary" on:click={primaryButtonClicked}>{primaryButtonTitle}</button>
+    <button class="button outlined thin secondary" on:click={secondaryButtonClicked}>{secondaryButtonTitle}</button>
 </div>
 
 
@@ -97,6 +97,7 @@ onMount(() => {
     flex-grow: 1;
     gap: 0.25rem;
     overflow: hidden;
+    font-size: 1.5rem;
 }
 .skeleton {
     // min-height: 0;
@@ -115,14 +116,22 @@ h2, p {
 h2 {
     margin-top: 1rem;
     font-weight: 600;
-    font-size: 1.5rem;
+    font-size: 1.5em;
+}
+p {
+    margin-top: 1rem;
 }
 
 pre {
     font-size: 0.75rem;
 }
 
-.sub-headline {
-    margin-top: 0;
+button.primary {
+    font-weight: 800;
+    background: white;
+}
+button.secondary {
+    margin-top: 0.25rem;
+    font-size: 0.8em;
 }
 </style>

--- a/svelte-web-frontend/src/lib/pages/DanceTreePage.svelte
+++ b/svelte-web-frontend/src/lib/pages/DanceTreePage.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import { goto } from '$app/navigation';
-import { page } from '$app/stores'
+import { page, navigating } from '$app/stores'
+import { navbarProps } from '$lib/elements/NavBar.svelte';
 
 import SketchButton from '$lib/elements/SketchButton.svelte';
 import type { DanceTree, Dance, DanceTreeNode } from '$lib/dances-store';
@@ -33,6 +34,14 @@ let showProgressNodes: Array<DanceTreeNode> = [];
 
 let videoDuration: number;
 
+$: navbarProps.set({
+    collapsed: false,
+    pageTitle: dance.title,
+    back: {
+        url: '/',
+        title: 'Home',
+    },
+});
 $: {
     showProgressNodes = currentPlayingNode !== null ? 
         [currentPlayingNode]:
@@ -40,6 +49,15 @@ $: {
 }
 $: if (videoCurrentTime > stopTime) {
     videoPaused = true;
+}
+
+$: {
+    navbarProps.update(props => ({
+        ...props,
+        pageTitle: dance.title,
+        backPageUrl: '/',
+        backPageTitle: 'Home',
+    }));
 }
 
 async function onNodeClicked(e: any) {
@@ -82,15 +100,6 @@ async function practiceClicked() {
 </svelte:head>
 
 <section>
-    <nav>
-        <a class="button" href="/">&lt; Home</a>
-        <h1 class="title">
-            {dance.title}
-        </h1>
-        <!-- Empty div, will take up the right side of the page -->
-        <div>
-        </div>
-    </nav>
     <div class="visual-tree">
         <div>
             <DanceTreeVisual 
@@ -107,7 +116,13 @@ async function practiceClicked() {
     <div class="ta-center">
         {#if currentPlayingNode}
         <span class="practiceLink">{currentPlayingNode.id}</span>
-        <SketchButton on:click={practiceClicked}>Practice</SketchButton>
+        <SketchButton on:click={practiceClicked} disabled={$navigating !== null}>
+            {#if $navigating}
+                Navigating <div class="spinner"></div>
+            {:else}
+                Practice
+            {/if}
+        </SketchButton>
         {/if}
     </div>
     
@@ -138,11 +153,11 @@ async function practiceClicked() {
 section {
     position: relative;
     width: 100vw;
-    height: 100vh;
+    height: var(--content_height);
     box-sizing: border-box;
     display: grid;
     overflow: hidden;
-    grid-template-rows: 3rem auto auto minmax(0, 1fr); 
+    grid-template-rows: auto auto minmax(0, 1fr); 
 }
 
 .preview {

--- a/svelte-web-frontend/src/lib/pages/PracticePage.svelte
+++ b/svelte-web-frontend/src/lib/pages/PracticePage.svelte
@@ -373,6 +373,8 @@ section {
     flex-direction: row;
     align-items: center;
     justify-content: stretch;
+    
+    box-sizing: border-box;
     height: 100%;
     width: 100%;
     gap: 1rem;

--- a/svelte-web-frontend/src/lib/pages/SettingsPage.svelte
+++ b/svelte-web-frontend/src/lib/pages/SettingsPage.svelte
@@ -34,11 +34,6 @@ const qijiaScoreMax = 5;
 </script>
 
 <section class="settingsPage">
-    <nav>
-        <a class="button outlined" href="/">&lt; Home</a>
-    </nav>
-    <h1>Settings</h1>
-
     <div>
         <label for="debugMode">Debug Mode</label>
         <input type="checkbox" name="debugMode" bind:checked={$debugMode}>
@@ -77,7 +72,9 @@ const qijiaScoreMax = 5;
     flex-direction: column;
     align-items: center;
     justify-content: start;
-    height: 100vh;
+    height: var(--content_height);
+    padding: 1rem;
+    box-sizing: border-box;
     gap: 0.5rem;
 }
 

--- a/svelte-web-frontend/src/lib/pages/SettingsPage.svelte
+++ b/svelte-web-frontend/src/lib/pages/SettingsPage.svelte
@@ -77,9 +77,4 @@ const qijiaScoreMax = 5;
     box-sizing: border-box;
     gap: 0.5rem;
 }
-
-nav {
-    width: 100%;
-    padding: 1rem;
-}
 </style>

--- a/svelte-web-frontend/src/routes/+layout.svelte
+++ b/svelte-web-frontend/src/routes/+layout.svelte
@@ -1,40 +1,16 @@
 <script>
-	import VirtualMirror from '$lib/elements/VirtualMirror.svelte';
-	import SketchButton from '$lib/elements/SketchButton.svelte';
-
+	import { writable } from 'svelte/store';
+	import { setContext } from 'svelte';
 	import { webcamStream } from '$lib/webcam/streams';
-
+	import NavBar, { navbarProps } from '$lib/elements/NavBar.svelte';
 	import './styles.scss';
-	import { onMount } from "svelte";
-
-
-	let webcamStarted = false;
-	// const dispatch = createEventDispatcher();
-
-	// function handleWebcamStarted();
-	// 	dispatch('webcamStarted', webcamStarted);
-	// }
 
 </script>
 
-<div class="app">
-	<!-- <div class="background"> -->
-		<!-- <VirtualMirror bind:webcamStarted /> -->
-	<!-- </div> -->
-	<!-- <Header /> -->
-
-	<!-- {#if webcamStarted}
-		<main>
-			<SketchButton>Hi</SketchButton>
-			<slot />
-		</main>
-	{/if} -->
+<div class="app" class:noNavBar={$navbarProps.collapsed}>
+	<NavBar />
 
 	<slot />
-
-	<!--  <footer>
-		<p>visit <a href="https://kit.svelte.dev">kit.svelte.dev</a> to learn SvelteKit</p>
-	</footer> -->
 
 	<div class="debug">
 		{$webcamStream}
@@ -49,6 +25,12 @@
 		min-height: 100vh;
 		align-items: start;
 		justify-content: center;
+		--navbar_height: 3rem;
+		--content_height: calc(100vh - var(--navbar_height));
+	}
+
+	.app.noNavBar {
+		--content_height: 100vh;
 	}
 
 	.debug {

--- a/svelte-web-frontend/src/routes/+page.svelte
+++ b/svelte-web-frontend/src/routes/+page.svelte
@@ -1,5 +1,14 @@
 <script lang="ts">
+import { navbarProps } from "$lib/elements/NavBar.svelte";
 import MainMenuPage from "$lib/pages/MainMenuPage.svelte";
+import { onMount } from "svelte";
+
+onMount(() => {
+	navbarProps.set({
+		collapsed: true,
+		pageTitle: "Home",
+	});
+});
 </script>
 
 <svelte:head>

--- a/svelte-web-frontend/src/routes/settings/+page.svelte
+++ b/svelte-web-frontend/src/routes/settings/+page.svelte
@@ -1,6 +1,20 @@
 <script lang="ts">
 import SettingsPage from "$lib/pages/SettingsPage.svelte";
 
+import { navbarProps } from "$lib/elements/NavBar.svelte";
+import { onMount } from "svelte";
+
+onMount(() => {
+    navbarProps.set({
+        collapsed: false,
+        pageTitle: "Settings",
+        back: {
+            url: "/",
+            title: "Home",
+        },
+    });
+});
+
 </script>
 
 <SettingsPage />

--- a/svelte-web-frontend/src/routes/styles.scss
+++ b/svelte-web-frontend/src/routes/styles.scss
@@ -126,7 +126,7 @@ button:focus:not(:focus-visible) {
 	color: var(--color-text);
 }
 .button {
-	padding: 0.25em;
+	padding: 0.5em;
 	// margin: 0.25em;
 	display: inline-block;
 	text-decoration: none;
@@ -181,24 +181,6 @@ button:focus:not(:focus-visible) {
 }
 .margin-auto {
 	margin: auto;
-}
-
-nav {
-	/* padding: 0.5rem; */
-	padding: 0 0.5em;
-	display: flex;
-	flex-direction: row;
-	justify-content: space-between;
-	align-items: center;
-	background: rgba(0, 0, 0, .2);
-	width: 100%;
-	flex-grow: 0;
-}
-
-nav h1 {
-	margin: 0;
-	padding: 0;
-	font-size: 2rem;
 }
 
 .spinner {

--- a/svelte-web-frontend/src/routes/teachlesson/[danceTreeId]/practicenode/[practiceNodeId]/+page.svelte
+++ b/svelte-web-frontend/src/routes/teachlesson/[danceTreeId]/practicenode/[practiceNodeId]/+page.svelte
@@ -4,6 +4,7 @@ import { GeneratePracticeActivity } from '$lib/ai/TeachingAgent';
 import { makeDanceTreeSlug, type DanceTree, type Dance, type DanceTreeNode } from '$lib/dances-store';
 import PracticePage from '$lib/pages/PracticePage.svelte';
 import { initialState, type PracticePageState } from '$lib/pages/PracticePage.svelte';
+import { navbarProps } from '$lib/elements/NavBar.svelte';
 
 /** @type {import('./$types').PageData} */    
 export let data;
@@ -25,14 +26,25 @@ $: {
 let pageState: PracticePageState = initialState;
 
 const StatesWithHiddenBackButton = new Set(["countdown", "playing", "paused"]);
-let hideBackButton = false;
+let hideNavBar = false;
 $: {
-    hideBackButton = StatesWithHiddenBackButton.has(pageState)
+    hideNavBar = StatesWithHiddenBackButton.has(pageState);
 }
+
+$: {
+    navbarProps.set({
+        collapsed: hideNavBar,
+        pageTitle: `${dance.title}: ${node.id}`,
+        back: {
+            url: parentURL,
+            title: 'Back',
+        },
+    });
+}
+
 </script>
 
-
-<section class="practiceNode">
+<section>
     <PracticePage 
         {dance} 
         {practiceActivity}
@@ -40,26 +52,13 @@ $: {
         on:continue-clicked={() => goto(parentURL)}
         on:stateChanged={(e) => pageState = e.detail}
     />
-    {#if !hideBackButton}
-        <a href={parentURL} class="button outlined back">&lt; {danceTree.tree_name}</a>
-    {/if}
 </section>
 
-
-
 <style lang="scss">
-
 section {
-    box-sizing: border-box;
-    height: 100vh;
+    height: var(--content_height);
     width: 100%;
     padding: 1rem;
-}
-
-.back {
-    position: absolute;
-    top: 1rem;
-    left: 1rem;
-    background-color: var(--color-bg-0);
+    box-sizing: border-box;
 }
 </style>


### PR DESCRIPTION
Prior to this PR, navigation in the app was an inconsistent page-by-page hack. This PR leverages `layout.page.svelte` to offer a consistent nav bar experience.

One of the challenges to doing this is giving child pages the ability to control the navbar, including altering the title and back button (more navbar configuration may be offered in the future). This is difficult because the typical flow of information is from parent to child, implementing using properties. This PR implements child > parent information flow by using a module-scoped store for navBar properties, which allows child pages to simply import the store and write to it. The navbar instance will then automatically pick up on this configuration changes and update accordingly.

Another challenge relates to sizing. We want the UI to behave like an app, taking up the full real-estate of the page. The presence or absence of the navbar affects the content size available to the rest of the page. In this implementation, we use CSS variables to communicate the content area sizing (remaining available height) to child components. 

closes #41.