### PR TITLE
feat: Integrating 3D pose to evaluation pipeline

### DIFF
--- a/svelte-web-frontend/.eslintrc.cjs
+++ b/svelte-web-frontend/.eslintrc.cjs
@@ -18,7 +18,7 @@ module.exports = {
 		parser: 'svelte-eslint-parser',
 		// Parse the `<script>` in `.svelte` as TypeScript
 		parserOptions: {
-			parser: '@typescript-eslint/parser'
+			parser: '@typescript-eslint/parser',
 		} 
 	}],
 	settings: {
@@ -32,5 +32,9 @@ module.exports = {
 		browser: true,
 		es2017: true,
 		node: true
+	},
+	rules: {
+		'@typescript-eslint/no-explicit-any': 0, // allow explicit any
+		'@typescript-eslint/no-unused-vars': [2, { argsIgnorePattern: '^_' }], // allow unused vars that start with `_`
 	}
 };

--- a/svelte-web-frontend/src/lib/DanceTreeVisual.svelte
+++ b/svelte-web-frontend/src/lib/DanceTreeVisual.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 import { debugMode } from './model/settings';
 import { createEventDispatcher } from 'svelte';
-import type { DanceTreeNode } from '$lib/dances-store';
+import type { DanceTreeNode } from '$lib/data/dances-store';
 
 export let enableClick: boolean = false;
 export let currentTime: number = 0;

--- a/svelte-web-frontend/src/lib/ai/TeachingAgent.ts
+++ b/svelte-web-frontend/src/lib/ai/TeachingAgent.ts
@@ -1,4 +1,4 @@
-import type { Dance, DanceTree, DanceTreeNode } from '../dances-store'
+import type { Dance, DanceTree, DanceTreeNode } from '../data/dances-store'
 import type PracticeActivity from '$lib/model/PracticeActivity';
 
 // export interface UserDancePerformanceLog {

--- a/svelte-web-frontend/src/lib/ai/UserDanceEvaluator.ts
+++ b/svelte-web-frontend/src/lib/ai/UserDanceEvaluator.ts
@@ -1,6 +1,6 @@
 import type { PoseReferenceData } from "$lib/data/dances-store";
 import type { Pose2DPixelLandmarks, Pose3DLandmarkFrame } from  "$lib/webcam/mediapipe-utils";
-import { QijiaMethodComparisionVectorNames, QijiaMethodComparisonVectors, getArrayMean } from './EvaluationCommonUtils';
+import { BodyInnerAnglesComparisons, QijiaMethodComparisionVectorNames, QijiaMethodComparisonVectors, getArrayMean } from './EvaluationCommonUtils';
 import { computeSkeleton2DDissimilarityJulienMethod, computeSkeleton3DVectorAngleSimilarity, computeSkeletonDissimilarityQijiaMethod } from "./skeleton-similarity";
 import { UserEvaluationRecorder } from "./UserEvaluationRecorder";
 
@@ -51,7 +51,7 @@ export class UserDanceEvaluatorV1 {
 
         const { 
             overallScore: angleSimilarity3DOverallScore,
-            vectorByVectorScores: angleSimilarity3DByVectorScores,
+            individualScores: angleSimilarity3DByVectorScores,
         } = computeSkeleton3DVectorAngleSimilarity(referencePose3D, userPose3D)
 
         const evaluationResult = { 
@@ -107,9 +107,8 @@ export class UserDanceEvaluatorV1 {
         const julienByVectorScores = new Map(julienVectorScoreKeyValues)
 
         const angleSimilarityOverallScore = getArrayMean(track.evaluation.angleSimilarity3DOverallScore);
-        const angleSimilarityVectorScoreKeyValues = QijiaMethodComparisonVectors.map((vec, i) => {
-            const key = QijiaMethodComparisionVectorNames[i];
-            const vecScores = track.evaluation.angleSimilarity3DByVectorScores.map((scores) => scores[i]);
+        const angleSimilarityVectorScoreKeyValues = Object.keys(BodyInnerAnglesComparisons).map((key) => {
+            const vecScores = track.evaluation.angleSimilarity3DByVectorScores.map((scores) => scores[key].score);
             const meanScore = getArrayMean(vecScores);
             return [key, meanScore] as [string, number];
         });

--- a/svelte-web-frontend/src/lib/data/dances-store.ts
+++ b/svelte-web-frontend/src/lib/data/dances-store.ts
@@ -1,6 +1,6 @@
 import Papa, { type ParseResult } from 'papaparse';
 
-import { PoseLandmarkKeysUpperSnakeCase , type Pose2DPixelLandmarks } from '$lib/webcam/mediapipe-utils';
+import { PoseLandmarkKeysUpperSnakeCase , type Pose2DPixelLandmarks, type Pose3DLandmarkFrame } from '$lib/webcam/mediapipe-utils';
 
 // import json data
 import dancesData from '$lib/data/bundle/dances.json';
@@ -93,7 +93,7 @@ function constrain(val: number, min: number, max: number) {
 /**
  * Reference data for a dance, in the form of an array of 2D pose landmarks for each frame of the dance.
  */
-export class Pose2DReferenceData {
+export class PoseReferenceData<T extends Pose2DPixelLandmarks | Pose3DLandmarkFrame> {
     
     /**
      * Create a new Pose2DReferenceData object
@@ -102,10 +102,9 @@ export class Pose2DReferenceData {
      * @param poses 2D pose landmarks for each frame of the reference data
      */
     constructor(
-        private danceId: string,
         private fps: number, 
         private frameIndices: number[],
-        private poses: Pose2DPixelLandmarks[]
+        private poses: T[]
     ) {
     }
 
@@ -114,7 +113,7 @@ export class Pose2DReferenceData {
      * @param timestamp Dance timestamp of the frame to get the pose for
      * @returns Pose information for the frame at the given timestamp, or null if no pose information is available for that frame
      */
-    getReferencePoseAtTime(timestamp: number): Pose2DPixelLandmarks | null {
+    getReferencePoseAtTime(timestamp: number): T | null {
 
         const targetFrameIndex = Math.floor(timestamp * this.fps);
 
@@ -134,34 +133,9 @@ export class Pose2DReferenceData {
     }
 }
 
-/**
- * Get the pose information for a dance. This is a CSV file with the pose information for 
- * each frame of the dance. It's returned in the form of an array of objects, where each object
- * is a frame of the dance, with keys corresponding to column names in the CSV file.
- * 
- * Example: 
- * ```
- * [{
- *  "frame": 0,
- *   "NOSE_x": 0.12,
- *   "NOSE_y": 0.34,
- *   "NOSE_z": 0.56,
- *    NOSE_vis": 0.98,
- *    "LEFT_EYE_INNER_x": 0.12,
- *    ...
- * },
- * ...]
- * ```
- * 
- * @param dance The dance to load the pose information for
- * @returns The pose information for the dance
- */
-export async function loadPoseInformation(dance: Dance): Promise<Pose2DReferenceData> {
-    const poseCsvPath = get2DPoseDataSrc(dance);
-    const response = await fetch(poseCsvPath);
+async function loadPoseInformation<T extends Pose2DPixelLandmarks | Pose3DLandmarkFrame>(csvpath: string, fps: number, rowToPose: (row: Record<string, number>) => T | null) {
+    const response = await fetch(csvpath);
     const text = await response.text();
-
-    // parse csv file
     const data: ParseResult<Record<string, never>> = await new Promise((res, rej) => {       
         Papa.parse(text, {
             header: true,
@@ -174,16 +148,38 @@ export async function loadPoseInformation(dance: Dance): Promise<Pose2DReference
     });
 
     // convert to array of pose information
-    return new Pose2DReferenceData(
-        dance.clipRelativeStem,
-        dance.fps, 
+    return new PoseReferenceData(
+        fps, 
         data.data.map((row) => +row[`frame`]), 
-        data.data.map((row) => GetPixelLandmarksFromPose2DRow(row))
-            .filter((pose) => pose !== null) as Pose2DPixelLandmarks[]
+        data.data.map((row) => rowToPose(row))
+                        .filter((pose) => pose !== null) as T[]
     )
 }
 
-function GetPixelLandmarksFromPose2DRow(pose2drow: Record<string, number>): Pose2DPixelLandmarks | null {
+/**
+ * Get the 2d pose information for a dance. It downloads a CSV file with the pose2d data, then converts
+ * the data into a 2d pixel landmark format
+ * @param dance The dance to load the pose information for
+ * @returns The pose information for the dance
+ */
+export async function load2DPoseInformation(dance: Dance): Promise<PoseReferenceData<Pose2DPixelLandmarks>> {
+    const pose2dCsvPath = get2DPoseDataSrc(dance);
+    return await loadPoseInformation(pose2dCsvPath, dance.fps, GetPixelLandmarksFromPose2DRow);
+}
+
+/**
+ * Get the 3d pose information for a dance. It downloads a CSV file with the holistic data, then converts
+ * the data into the 3d landmark format that mediapipe uses (but with the added visiblity component that as
+ * of 2023-09-18 is only present in the python solution).
+ * @param dance The dance to load the pose information for
+ * @returns The pose information for the dance.
+ */
+export async function load3DPoseInformation(dance: Dance): Promise<PoseReferenceData<Pose3DLandmarkFrame>> {
+    const pose3dCsvPath = getHolisticDataSrc(dance);
+    return await loadPoseInformation(pose3dCsvPath, dance.fps, GetPixelLandmarksFromPose3DRow);
+}
+
+function GetPixelLandmarksFromPose2DRow(pose2drow: Record<string, number>) {
     if (!pose2drow) return null;
 
     return PoseLandmarkKeysUpperSnakeCase.map((key) => {
@@ -192,6 +188,19 @@ function GetPixelLandmarksFromPose2DRow(pose2drow: Record<string, number>): Pose
             y: pose2drow[`${key}_y`],
             dist_from_camera: pose2drow[`${key}_distance`],
             visibility: pose2drow[`${key}_vis`]
+        }
+    });
+}
+
+function GetPixelLandmarksFromPose3DRow(pose3drow: Record<string, number>) {
+    if (!pose3drow) return null;
+    
+    return PoseLandmarkKeysUpperSnakeCase.map((key) => {
+        return {
+            x: pose3drow[`${key}_x`],
+            y: pose3drow[`${key}_y`],
+            z: pose3drow[`${key}_z`],
+            vis: pose3drow[`${key}_vis`]
         }
     });
 }

--- a/svelte-web-frontend/src/lib/elements/VideoWithSkeleton.svelte
+++ b/svelte-web-frontend/src/lib/elements/VideoWithSkeleton.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 
-import type { Dance, Pose2DReferenceData } from "$lib/dances-store";
+import type { Dance, PoseReferenceData } from "$lib/data/dances-store";
 import { onDestroy, onMount } from "svelte";
 import { type Pose2DPixelLandmarks, GetNormalizedLandmarksFromPixelLandmarks } from "$lib/webcam/mediapipe-utils";
 import { DrawingUtils, PoseLandmarker, type NormalizedLandmark } from "@mediapipe/tasks-vision";
@@ -30,7 +30,7 @@ export let duration = 0;
 export let ended: boolean = false;
 
 export let dance: Dance | null = null;
-export let poseData: Pose2DReferenceData | null = null;
+export let poseData: PoseReferenceData<Pose2DPixelLandmarks> | null = null;
 export let drawSkeleton: boolean = true;
 
 let videoElementWidth: number = 0;

--- a/svelte-web-frontend/src/lib/elements/VirtualMirror.svelte
+++ b/svelte-web-frontend/src/lib/elements/VirtualMirror.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { PoseLandmarkKeys } from '$lib/webcam/mediapipe-utils';
+	import { PoseLandmarkKeys, type Pose3DLandmarkFrame } from '$lib/webcam/mediapipe-utils';
 	// import { PoseEstimationWorker } from '$lib/pose-estimation.worker?worker';
     import PoseEstimationWorker, { worker, PostMessages as PoseEstimationMessages, ResponseMessages as PoseEsimationResponses } from '$lib/webcam/pose-estimation.worker';
     import { DrawingUtils, PoseLandmarker, type NormalizedLandmark, type PoseLandmarkerResult } from "@mediapipe/tasks-vision";
@@ -48,7 +48,7 @@
     let lastFrameDecoded = -1;
     const poseEstimationInterFrameIdleTime = 50; // wait 50ms before dispatching the next frame.
 
-    let lastEstimatedPose: null | NormalizedLandmark[] = null;
+    let lastEstimated2DPose: null | NormalizedLandmark[] = null;
 
     let videoWidth = 1;
     let videoHeight = 1;
@@ -105,11 +105,18 @@
                 }
 
                 lastFrameDecoded = msg.data.frameId;
-                lastEstimatedPose = msg.data.estimatedPose;
+                const landmarkerResult = msg.data.landmarkerResult as PoseLandmarkerResult | null;
+                const allDetectedPersonsNormalizedLandmarks = landmarkerResult?.landmarks ?? [];
+                const estimated2DPose = allDetectedPersonsNormalizedLandmarks[0] ?? null; // get the pose of the first detected person
+                lastEstimated2DPose = estimated2DPose
+
+                const allDetectedPersons3DLandmarks = landmarkerResult?.worldLandmarks ?? [];
+                const estimated3DPose = allDetectedPersons3DLandmarks[0] ?? null; // get the pose of the first detected person
                 
                 const eventDetail = {
                     frameId: msg.data.frameId as number,
-                    estimatedPose: msg.data.estimatedPose as NormalizedLandmark[] | null,
+                    estimated2DPose: lastEstimated2DPose as NormalizedLandmark[] | null,
+                    estimated3DPose: estimated3DPose as Pose3DLandmarkFrame | null,
                     srcWidth: msg.data.srcWidth as number,
                     srcHeight: msg.data.srcHeight as number,
                 }
@@ -123,12 +130,12 @@
 
                 if (msg.data.frameId === lastFrameSent) {
                     lastFrameSent = -1;
-                    lastEstimatedPose = null;
+                    lastEstimated2DPose = null;
                 }
             } else if (msg.data.type == PoseEsimationResponses.resetComplete) {
                 console.log("Pose Estimation Reset Complete");
                 lastFrameSent = -1;
-                lastEstimatedPose = null;
+                lastEstimated2DPose = null;
             }
         };
 
@@ -279,7 +286,7 @@
         }
 
         // Use the custom draw function. This allows for higher specificity
-        customDrawFn?.(canvasContext, lastEstimatedPose);
+        customDrawFn?.(canvasContext, lastEstimated2DPose);
 
         // Leave early if we're not drawing the skeleton
         if (!drawSkeleton) {
@@ -297,13 +304,13 @@
         // canvasContext.scale(drawWidth / videoElement.videoWidth, drawHeight / videoElement.videoHeight);
         // canvasContext.translate(drawX, drawY);
 
-        if(lastEstimatedPose && lastEstimatedPose.length === PoseLandmarkKeys.length) {
+        if(lastEstimated2DPose && lastEstimated2DPose.length === PoseLandmarkKeys.length) {
             drawingUtils?.drawConnectors(
-                lastEstimatedPose,
+                lastEstimated2DPose,
                 PoseLandmarker.POSE_CONNECTIONS
             )
             drawingUtils?.drawLandmarks(
-                lastEstimatedPose, {
+                lastEstimated2DPose, {
                     radius: (data) => DrawingUtils.lerp(data.from!.z, -0.15, 0.1, 5, 1)
                 }
             );

--- a/svelte-web-frontend/src/lib/elements/VirtualMirror.svelte
+++ b/svelte-web-frontend/src/lib/elements/VirtualMirror.svelte
@@ -176,15 +176,15 @@
         }
     }
 
-    onMount(async () => {		
+    onMount(() => {		
 		
         // Start pose estimation, if enabled
         if (poseEstimationEnabled) {
             setupPoseEstimation();
         }
 
-        await tick()
-        resizeCanvas();
+        // Schedule a canvas resize
+        tick().then(resizeCanvas);
 
         const resizeObserver = new ResizeObserver(entries => {
             if (!containerElement) return;

--- a/svelte-web-frontend/src/lib/model/TerminalFeedback.ts
+++ b/svelte-web-frontend/src/lib/model/TerminalFeedback.ts
@@ -1,4 +1,4 @@
-import type { ValueOf } from "$lib/dances-store";
+import type { ValueOf } from "$lib/data/dances-store";
 
 export const TerminalFeedbackBodyParts = {
     'head': 0,

--- a/svelte-web-frontend/src/lib/pages/DanceTreePage.svelte
+++ b/svelte-web-frontend/src/lib/pages/DanceTreePage.svelte
@@ -4,8 +4,7 @@ import { page, navigating } from '$app/stores'
 import { navbarProps } from '$lib/elements/NavBar.svelte';
 
 import SketchButton from '$lib/elements/SketchButton.svelte';
-import type { DanceTree, Dance, DanceTreeNode } from '$lib/dances-store';
-import { getDanceVideoSrc } from '$lib/dances-store';
+import { getDanceVideoSrc, type Dance, type DanceTree, type DanceTreeNode } from '$lib/data/dances-store';
 import DanceTreeVisual from '$lib/DanceTreeVisual.svelte';
 import { tick } from 'svelte';
 

--- a/svelte-web-frontend/src/lib/pages/MainMenuPage.svelte
+++ b/svelte-web-frontend/src/lib/pages/MainMenuPage.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-import { dances, danceTrees, makeDanceTreeSlug } from '$lib/dances-store';
-import type { DanceTree, Dance } from '$lib/dances-store';
+import { dances, danceTrees, makeDanceTreeSlug } from '$lib/data/dances-store';
+import type { DanceTree, Dance } from '$lib/data/dances-store';
 import FolderMenu from '$lib/elements/FolderMenu.svelte';
 import type { FolderContents, FolderMenuItem, FileMenuItem, MenuItem } from '$lib/elements/FolderMenu.svelte';
 

--- a/svelte-web-frontend/src/lib/pages/PracticePage.svelte
+++ b/svelte-web-frontend/src/lib/pages/PracticePage.svelte
@@ -14,7 +14,7 @@ import { generateFeedbackRuleBased, generateFeedbackWithClaudeLLM} from '$lib/ai
 import { DrawColorCodedSkeleton } from '$lib/ai/SkeletonFeedbackVisualization'
 import VideoWithSkeleton from "$lib/elements/VideoWithSkeleton.svelte";
 import VirtualMirror from "$lib/elements/VirtualMirror.svelte";
-import metronomeClickSoundSrc from '$lib/media/audio/metronome-click.mp3';
+import metronomeClickSoundSrc from '$lib/media/audio/metronome.mp3';
 
 import { onMount, createEventDispatcher } from "svelte";
 import { webcamStream } from '$lib/webcam/streams';
@@ -114,9 +114,11 @@ $: {
                 QIJIA_SKELETON_SIMILARITY_MAX_SCORE,
             ).then((feedback) => {
                 terminalFeedback = feedback;
+                terminalFeedback.debugJson = performanceSummary ?? undefined;
             }).catch((e) => {
                 console.warn("Error generating feedback", e);
                 terminalFeedback = generateFeedbackRuleBased(qijiaOverallScore, qijiaByVectorScores);
+                terminalFeedback.debugJson = performanceSummary ?? undefined;
             });
         }
         else {

--- a/svelte-web-frontend/src/lib/webcam/mediapipe-utils.ts
+++ b/svelte-web-frontend/src/lib/webcam/mediapipe-utils.ts
@@ -1,6 +1,6 @@
 import type { Landmark, NormalizedLandmark, PoseLandmarkerResult } from '@mediapipe/tasks-vision'
 import { SwapMultipleArrayElements } from '$lib/utils/array';
-import type { ValueOf } from '$lib/dances-store';
+import type { ValueOf } from '$lib/data/dances-store';
 
 export const PoseLandmarkIds = Object.freeze({
     nose: 0,
@@ -41,25 +41,68 @@ export type PoseLandmarkIndex = ValueOf<typeof PoseLandmarkIds>;
 type PoseLandmarkName = keyof typeof PoseLandmarkIds;
 export const PoseLandmarkKeys = Object.freeze(Object.getOwnPropertyNames(PoseLandmarkIds)) as readonly PoseLandmarkName[];
 
-export type Pose3DLandmarks = PoseLandmarkerResult["worldLandmarks"];
-export type Pose2DNormalizedLandmarks = PoseLandmarkerResult["landmarks"]
-export type AnyLandmark = NormalizedLandmark | Landmark | PixelLandmark;
+/**
+ * Represents a frame with 32 normalized 2D landmarks, corresponding to different parts of the body as
+ * specified by [mediapipe's documentation](https://developers.google.com/mediapipe/solutions/vision/pose_landmarker), 
+ * with coordinates between 0 and 1. (0, 0) is the left, top of the image, and (1, 1) is the right, 
+ * bottom of the image. Note that this normalization doesn't take into account the aspect ratio of 
+ * the image, so the scales of the x and y components of thelandmark are of different scales.
+ * 
+ * There is a z component, which at the same scale as the x component, corresponding to the distance
+ * from the camera.
+ * 
+ * @
+ * 
+ * @see [Output Format](https://developers.google.com/mediapipe/solutions/vision/pose_landmarker/web_js#handle_and_display_results)
+ */
+export type Pose2DNormalizedLandmarkFrame = PoseLandmarkerResult["landmarks"][0];
 
 /**
- * Represents a pixel landmark
+ * Represents a 3d landmark, returned as part of mediapipe's `worldLandmarks` output. The scale here
+ * is approximately in meters, but the exact scale is unknown. These are not normalized.
+ */
+export type Landmark3D = Landmark;
+
+/**
+ * Represents a 3d landmark, returned as part of mediapipe's `worldLandmarks` output, with an added
+ * visibiltiy component between [0, 1]. The scale here is approximately in meters, but the exact 
+ * scale is unknown. These are not normalized.
+ */
+export type Landmark3DWithVisibility = Landmark3D & {
+    vis: number;
+}
+
+/**
+ * A frame with 32 3D landmarks, corresponding to different parts of the body as specified by
+ * [mediapipe's documentation](https://developers.google.com/mediapipe/solutions/vision/pose_landmarker).
+ */
+export type Pose3DLandmarkFrame = Landmark3D[];
+
+/**
+ * A frame with 32 3D landmarks, corresponding to different parts of the body as specified by
+ * [mediapipe's documentation](https://developers.google.com/mediapipe/solutions/vision/pose_landmarker).
+ * These landmarks also have a visibility component, which is a number between 0 and 1, where 0
+ * means the landmark is not visible, and 1 means the landmark is fully visible.
+ * This is returned as part of mediapipe's `worldLandmarks` output in the python solution, and is
+ * stored in our .holisticdata CSV files.
+ */
+export type Pose3DLandmarkWithVisibilityFrame = Landmark3D[];
+
+/**
+ * Represents any landmark.
+ */
+export type AnyLandmark = NormalizedLandmark | PixelLandmark | Landmark3D;
+
+/**
+ * Represents a 2d landmark, converted to pixel coordinates. 
  */
 type PixelLandmark = {
     x: number;
     y: number;
     dist_from_camera: number;
-    visibility: number;
+    visibility?: number;
 }
 export type Pose2DPixelLandmarks = PixelLandmark[]
-
-
-// export function Get3DLandmarksFromHolisticRow(holisticRow: any): Pose3DLandmarks {
-//     return [];
-// }
 
 /**
  * Convert a string from camelCase to snake_case
@@ -101,8 +144,15 @@ export function SwapLeftRightLandmarks<T extends AnyLandmark>(pose: T[]) {
     return copiedPose;
 }
 
-export function MirrorXNormalizedPose<T extends AnyLandmark>(pose: T[]): T[] {
-    const xFlipped = pose.map(lm => ({
+/**
+ * Mirror a pose frame along the x axis. This is useful for mirroring a pose frame of a user
+ * in a webcam, so that the user's left side is on the left side of the frame, and the user's
+ * right side is on the right side of the frame.
+ * @param pose Pose Frame to mirror
+ * @returns Mirrored pose frame
+ */
+export function MirrorXPose<T extends AnyLandmark>(poseFrame: T[]): T[] {
+    const xFlipped = poseFrame.map(lm => ({
         ...lm,
         x: 1 - lm.x,
     }));
@@ -113,12 +163,21 @@ export function MirrorXNormalizedPose<T extends AnyLandmark>(pose: T[]): T[] {
 export function GetPixelLandmarksFromNormalizedLandmarks(normalizedLandmarks: NormalizedLandmark[], srcWidth: number, srcHeight: number): Pose2DPixelLandmarks | null {
     if ((normalizedLandmarks?.length ?? 0) <= 0) return null;
     
-    return normalizedLandmarks.map((lm, i) => ({
-        x: lm.x * srcWidth,
-        y: lm.y * srcHeight,
-        dist_from_camera: lm.z * srcWidth,
-        visibility: (lm as any)["visibility"] ?? 1.0,
-    }));
+    return normalizedLandmarks.map((lm) => {
+        const landmark = {
+            x: lm.x * srcWidth,
+            y: lm.y * srcHeight,
+            dist_from_camera: lm.z * srcWidth,
+        }
+        const visibility_value = (lm as unknown as Record<string, number>)["visibility"];
+        if (visibility_value !== undefined) {
+            return {
+                ...landmark,
+                visibility: visibility_value,
+            }
+        };
+        return landmark;
+    });
 }
 
 export function GetNormalizedLandmarksFromPixelLandmarks(

--- a/svelte-web-frontend/src/lib/webcam/pose-estimation.worker.ts
+++ b/svelte-web-frontend/src/lib/webcam/pose-estimation.worker.ts
@@ -50,11 +50,14 @@ async function loadPoseLandmarkerModel() {
     return poseLandmarker;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+function no_op(){}
+
 export default class PoseEstimationWorker {
 
     private poseLandmarker: null | PoseLandmarker = null;
 
-    public onmessage: (msg: any) => void = () => {};
+    public onmessage: (msg: any) => void = no_op;
 
     public ready: Promise<void>;
 
@@ -119,7 +122,7 @@ export default class PoseEstimationWorker {
         this.responseFunctions.get(msgData.type)?.(frameId, msgData);
     }
 
-    private handleReset(frameId: number, msgData: any) {
+    private handleReset(frameId: number, _msgData: any) {
         this.poseLandmarker?.close();
         this.poseLandmarker = null;
         this.ready = loadPoseLandmarkerModel().then((poseLandmarker) => {

--- a/svelte-web-frontend/src/lib/webcam/pose-estimation.worker.ts
+++ b/svelte-web-frontend/src/lib/webcam/pose-estimation.worker.ts
@@ -61,14 +61,9 @@ export default class PoseEstimationWorker {
     private responseFunctions: Map<PostMessages, (id: number, msg: any) => void> = new Map();
 
     constructor() {
-        this.ready = new Promise(async (res, rej) => {
-            try {
-                this.poseLandmarker = await loadPoseLandmarkerModel();
-                res();
-            } catch (e) {
-                rej(e);
-            }
-        })
+        this.ready = loadPoseLandmarkerModel().then((poseLandmarker) => {
+            this.poseLandmarker = poseLandmarker;
+        });
 
         this.responseFunctions.set(
             PostMessages.requestPoseEstimation, 
@@ -127,18 +122,14 @@ export default class PoseEstimationWorker {
     private handleReset(frameId: number, msgData: any) {
         this.poseLandmarker?.close();
         this.poseLandmarker = null;
-        this.ready = new Promise(async (res, rej) => {
-            try {
-                this.poseLandmarker = await loadPoseLandmarkerModel();
-                res();
-                this.respondWithMessage(ResponseMessages.resetComplete, frameId, {});
-            } catch (e) {
-                rej(e);
-                this.respondWithMessage(ResponseMessages.resetError, frameId, {
-                    error: e
-                });
-            }
-        })
+        this.ready = loadPoseLandmarkerModel().then((poseLandmarker) => {
+            this.poseLandmarker = poseLandmarker;
+            this.respondWithMessage(ResponseMessages.resetComplete, frameId, {});
+        }, (e) => {
+            this.respondWithMessage(ResponseMessages.resetError, frameId, {
+                error: e,
+            });
+        });
     }
 
     private handlePoseEstimationRequest(frameId: number, msgData: any) {
@@ -165,12 +156,8 @@ export default class PoseEstimationWorker {
             msgData.timestampMs
         )
 
-        const allNormalizedPoses = (poseLandmarkerResult?.landmarks ?? [])
-        const firstUserPose = allNormalizedPoses[0] ?? null;
-
         this.respondWithMessage(ResponseMessages.poseEstimation, frameId, {
             landmarkerResult: poseLandmarkerResult,
-            estimatedPose: firstUserPose,
             srcWidth: msgData.image.width,
             srcHeight: msgData.image.height
         });

--- a/svelte-web-frontend/src/routes/teachlesson/[danceTreeId]/+page.svelte
+++ b/svelte-web-frontend/src/routes/teachlesson/[danceTreeId]/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import DanceTreePage from "$lib/pages/DanceTreePage.svelte";
-import type { DanceTree, Dance } from '$lib/dances-store';
+import type { DanceTree, Dance } from '$lib/data/dances-store';
 
 /** @type {import('./$types').PageData} */    
 export let data;

--- a/svelte-web-frontend/src/routes/teachlesson/[danceTreeId]/+page.ts
+++ b/svelte-web-frontend/src/routes/teachlesson/[danceTreeId]/+page.ts
@@ -1,6 +1,6 @@
 import { error } from '@sveltejs/kit';
 
-import { getDanceAndDanceTreeFromDanceTreeId } from '$lib/dances-store.js';
+import { getDanceAndDanceTreeFromDanceTreeId } from '$lib/data/dances-store.js';
 
 import type { PageLoad } from './$types';
 

--- a/svelte-web-frontend/src/routes/teachlesson/[danceTreeId]/practicenode/[practiceNodeId]/+page.svelte
+++ b/svelte-web-frontend/src/routes/teachlesson/[danceTreeId]/practicenode/[practiceNodeId]/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 import { goto } from '$app/navigation';
 import { GeneratePracticeActivity } from '$lib/ai/TeachingAgent';
-import { makeDanceTreeSlug, type DanceTree, type Dance, type DanceTreeNode } from '$lib/dances-store';
+import { makeDanceTreeSlug, type DanceTree, type Dance, type DanceTreeNode } from '$lib/data/dances-store';
 import PracticePage from '$lib/pages/PracticePage.svelte';
 import { initialState, type PracticePageState } from '$lib/pages/PracticePage.svelte';
 import { navbarProps } from '$lib/elements/NavBar.svelte';

--- a/svelte-web-frontend/src/routes/teachlesson/[danceTreeId]/practicenode/[practiceNodeId]/+page.ts
+++ b/svelte-web-frontend/src/routes/teachlesson/[danceTreeId]/practicenode/[practiceNodeId]/+page.ts
@@ -1,6 +1,6 @@
 import { error } from '@sveltejs/kit';
 
-import { getDanceAndDanceTreeFromDanceTreeId, findDanceTreeNode } from '$lib/dances-store.js';
+import { getDanceAndDanceTreeFromDanceTreeId, findDanceTreeNode } from '$lib/data/dances-store.js';
 
 import type { PageLoad } from './$types';
 


### PR DESCRIPTION
This implements front-end use of 3d pose information for the purpose of motion evaluation.

- Added a method for loading 3d pose information from holistic data
- Piped 3d pose information from mediapipe through to the evaluator and evaluation recorder.
- Implemented our first method that uses 3d pose information: an 3d vector-angle similarity metric. This is just like the qijia similarity method, but performs the comparison in 3D.

Closes #56.

Todo:

- [x] Validate the 3d angle similarity computation. 
    - [x] in particular, look at the coordinate frames to see how consistent they are
    - [x] test out the mirroring method for 3d landmarks.