### PR TITLE
Adding achievements, fixing layout bugs

### DIFF
--- a/svelte-web-frontend/src/lib/ai/backend/anthropic.ts
+++ b/svelte-web-frontend/src/lib/ai/backend/anthropic.ts
@@ -35,15 +35,17 @@ export async function getFeedback(
     currentSectionName: string,
     performanceDistillation: string,
     performanceHistoryDistillation: string,
-
+    achivementsDistillation?: string,
 ){
     
+    const achievmentDistillationEntry = achivementsDistillation ? `<achievmentsDistillation>${achivementsDistillation}</achievmentsDistillation>` : '';
+
     const dynamicData = `
 <danceStructureDistillation>${danceStructureDistillation}</danceStructureDistillation>
 <currentSectionName>${currentSectionName}</currentSectionName>
 <performanceDistillation>${performanceDistillation}</performanceDistillation>
 <performanceHistoryDistillation>${performanceHistoryDistillation}</performanceHistoryDistillation>
-`
+${achievmentDistillationEntry}`
     
     const prompt = taskStatement + example + dynamicData + Anthropic.AI_PROMPT;
     

--- a/svelte-web-frontend/src/lib/ai/detectAchievements.ts
+++ b/svelte-web-frontend/src/lib/ai/detectAchievements.ts
@@ -1,0 +1,104 @@
+import { formatOrdinals } from "$lib/utils/formatting";
+import type { FrontendDancePeformanceHistory } from "./frontendPerformanceHistory";
+
+export const OutputTarget = Object.freeze({
+    user: 'user',
+    system: 'system'
+});
+export type OutputTargetType = keyof typeof OutputTarget;
+
+export type AchievementParams = {
+    performanceHistory: FrontendDancePeformanceHistory;
+    attemptedNodeId: string;
+    outputTarget: OutputTargetType;
+}
+
+const SINGLE_NODE_ATTEMPT_ACHIEVEMENTS = new Map([
+        [5, 'Good job!'], 
+        [10, 'Nice work!'], 
+        [15, 'Great persistance!'], 
+        [20, 'Incredible persistence!'],
+]);
+
+export function getSingleNodeAttemptAchivement(attemptCount: number, sectionName: string, outputTarget: OutputTargetType) {
+    const exalamation = SINGLE_NODE_ATTEMPT_ACHIEVEMENTS.get(attemptCount);
+    if (exalamation === undefined) {
+        return null;
+    }
+
+    if (outputTarget === OutputTarget.user) {
+        return `${exalamation} That was your ${formatOrdinals(attemptCount)} attempt for section '${sectionName}'!`
+    }
+    if (outputTarget === OutputTarget.system) {
+        return `User has attempted section '${sectionName}' ${attemptCount} times.`
+    }
+    
+    throw new Error('Unknown output target: ' + outputTarget);
+}
+
+
+const defaultAllNodeAchievementSuffixFunction = (attemptCount: number) => `That was your ${formatOrdinals(attemptCount)} attempt!`;
+const ALL_NODES_ATTEMPT_ACHIEVEMENTS = new Map([
+    [1, { prefix: 'Great start!', suffixFn: (attemptCount: number) => `You've completed your ${formatOrdinals(attemptCount)} attempt!` }],
+    [5, { prefix: 'That a way!', suffixFn: defaultAllNodeAchievementSuffixFunction }],
+    [10, { prefix: 'Keep it up!', suffixFn: (attemptCount: number) => `You've reached ${attemptCount} total attempts!` }],
+    [25, { prefix: 'Amazing!', suffixFn: defaultAllNodeAchievementSuffixFunction }],
+    [40, { prefix: "You're a rockstar!", suffixFn: defaultAllNodeAchievementSuffixFunction }],
+    [50, { prefix: 'Incredible!', suffixFn: defaultAllNodeAchievementSuffixFunction }],
+    [100, { prefix: 'Absolutely incredible!', suffixFn: defaultAllNodeAchievementSuffixFunction }],
+]);
+
+export function getAllNodesAttemptAchievement(attemptCount: number, outputTarget: OutputTargetType) {
+    const exalamation = ALL_NODES_ATTEMPT_ACHIEVEMENTS.get(attemptCount);
+    if (exalamation === undefined) { 
+        return null; 
+    }
+
+    if (outputTarget === OutputTarget.user) {
+        return `${exalamation.prefix} ${exalamation.suffixFn(attemptCount)}`;
+    }
+    if (outputTarget === OutputTarget.system) {
+        return `User has reached ${attemptCount} attempts total across all practice sections.`
+    }
+    
+    throw new Error('Unknown output target: ' + outputTarget);
+}
+
+export default function detectAchievements(params: AchievementParams): string[] {
+    
+    let achievements = [] as string[];
+
+    const singleNodeAttemptCount = getAttemptCount(params, 1, 'attemptedNode');
+    const singleNodeAchivement = getSingleNodeAttemptAchivement(singleNodeAttemptCount, params.attemptedNodeId, params.outputTarget);
+    if (singleNodeAchivement) {
+        achievements.push(singleNodeAchivement);
+    }
+
+    const allNodeAttemptCounts = getAttemptCount(params, 1, 'allNodes');
+    const allNodeAchivement = getAllNodesAttemptAchievement(allNodeAttemptCounts, params.outputTarget);
+    if (allNodeAchivement) {
+        achievements.push(allNodeAchivement);
+    }
+
+    // achievements.push('Congrats! You have an achievement!');
+
+    return achievements
+}
+
+export function getAttemptCount(params: AchievementParams, nTrials: number, target: 'attemptedNode' | 'allNodes'): number {
+
+    let attemptCount: number;
+    if (target === 'attemptedNode') {
+        const basicMetricEntries = params.performanceHistory?.[params.attemptedNodeId]?.basicInfo ?? [];
+        attemptCount = basicMetricEntries.filter(x => x.partOfLargerPerformance === false).length;
+    }
+    else if (target === 'allNodes') {
+        const allSegmentEntries = params.performanceHistory ?? {};
+        attemptCount = Object.values(allSegmentEntries).flatMap(x => x.basicInfo ?? []).filter(x => x.partOfLargerPerformance === false).length;
+    } else {
+        throw new Error('Unknown target: ' + target);
+    }
+
+    return attemptCount;
+}
+

--- a/svelte-web-frontend/src/lib/elements/StaticSkeletonVisual.svelte
+++ b/svelte-web-frontend/src/lib/elements/StaticSkeletonVisual.svelte
@@ -50,6 +50,7 @@ const allBodyParts = Object.keys(bodyPartPaths) as TerminalFeedbackBodyPart[];
 
 <style lang="scss">
 svg {
+    height: 100%;
     max-height: 100%;
     max-width: 100%;
     min-height: 150px;

--- a/svelte-web-frontend/src/lib/elements/TerminalFeedbackScreen.svelte
+++ b/svelte-web-frontend/src/lib/elements/TerminalFeedbackScreen.svelte
@@ -136,13 +136,12 @@ function exportRecordings() {
     
     {#if feedback?.paragraphs}
     <div class="paragraphs">
-        <SpeechInterface textToSpeak={feedback.paragraphs.map(x => x?.trim()).join("\n\n")}/>
+        <SpeechInterface textToSpeak={[
+            ...feedback.paragraphs.map(x => x?.trim()),
+            ...(feedback.incorrectBodyPartsToHighlight ?? []).map(x => `Try focusing on your ${x} next time.`)
+        ].join("\n\n")}/>
     </div>
     {/if}
-    <div class="info ta-center outlined thin dashed p-1">
-        <span class="icon"><Icon type={Icons.info} /></span>
-        <span class="message">Click any part of the dance above to practice that segment.</span>
-    </div>
     <!-- {#each feedback?.paragraphs ?? [] as paragraph}
         <p>{paragraph}</p>
     {/each} -->
@@ -150,9 +149,7 @@ function exportRecordings() {
     {#if feedback?.score}
         <p><code>Score: {feedback.score.achieved.toFixed(2)} / {feedback.score.maximumPossible.toFixed(2)}</code></p>
     {/if}
-    {#each feedback?.incorrectBodyPartsToHighlight ?? [] as badbodypart}
-        <p>Try focusing on your {badbodypart} next time.</p>
-    {/each}
+
     {#if skeletonHighlights.length > 0}
     <div class="skeleton">
         <StaticSkeletonVisual 
@@ -160,6 +157,10 @@ function exportRecordings() {
         />
     </div>
     {/if}
+    <div class="info ta-center outlined thin dashed p-1 mt-1">
+        <span class="icon"><Icon type={Icons.info} /></span>
+        <span class="message">Click any part of the dance above to practice that segment.</span>
+    </div>
     {#if buttons.length > 0}
     <div class="buttons">
     {#each buttons as button, i}

--- a/svelte-web-frontend/src/lib/pages/PracticePage.svelte
+++ b/svelte-web-frontend/src/lib/pages/PracticePage.svelte
@@ -238,7 +238,14 @@ async function getFeedback(performanceSummary: FrontendPerformanceSummary | null
     }
 
     if (!feedback) {
-        feedback = generateFeedbackRuleBased(qijiaOverallScore, qijiaByVectorScores);
+        const perfHistory = $frontendPerformanceHistory;
+        const dancePerfHistory = practiceActivity?.dance?.clipRelativeStem ? perfHistory?.[practiceActivity.dance.clipRelativeStem] ?? null : null;
+        feedback = generateFeedbackRuleBased(
+            qijiaOverallScore, 
+            qijiaByVectorScores,
+            dancePerfHistory ?? undefined,
+            practiceActivity?.danceTreeNode?.id,
+        );
     }
     
     feedback.debug = {
@@ -639,9 +646,11 @@ onMount(() => {
 div.demovid { grid-area: demovid; }
 div.mirror {  grid-area: mirror;  }
 div.treevis { grid-area: treevis; }
-div.feedback { grid-area: feedback; }
+
+div.feedback { grid-area: feedback; overflow: hidden;}
 
 section {
+    overflow: hidden;
     display: grid;
     grid-template: "demovid mirror" 1fr / 1fr 1fr;
 

--- a/svelte-web-frontend/src/lib/utils/formatting.ts
+++ b/svelte-web-frontend/src/lib/utils/formatting.ts
@@ -14,3 +14,33 @@ export function replaceJSONForStringifyDisplay(key: any, value: any) {
 
   return value;
 }
+
+const enOrdinalRules = new Intl.PluralRules("en-US", { type: "ordinal" });
+
+const suffixes = new Map([
+  ["one", "st"],
+  ["two", "nd"],
+  ["few", "rd"],
+  ["other", "th"],
+]);
+
+/**
+ * Takes a number and returns a string representing the ordinal of the number
+ * @param n Number to format as an ordinal
+ * @returns A string representing the ordinal of the number
+ * 
+ * @example
+ * formatOrdinals(0) // "0th"
+ * formatOrdinals(1) // "1st"
+ * formatOrdinals(2) // "2nd"
+ * formatOrdinals(3) // "3rd"
+ * formatOrdinals(4) // "4th"
+ * formatOrdinals(11) // "11th" (not "11st")
+ * formatOrdinals(13) // "13th" (not "13rd")
+ * formatOrdinals(21) // "21st"
+ */
+export function formatOrdinals(n: number) {
+  const rule = enOrdinalRules.select(n);
+  const suffix = suffixes.get(rule);
+  return `${n}${suffix}`;
+};

--- a/svelte-web-frontend/src/routes/restapi/get_feedback/+server.ts
+++ b/svelte-web-frontend/src/routes/restapi/get_feedback/+server.ts
@@ -10,6 +10,7 @@ export async function POST(event: RequestEvent) {
     const currentSectionName = data.currentSectionName;
     const performanceDistillation = data.performanceDistillation;
     const performanceHistoryDistillation = data.performanceHistoryDistillation;
+    const achivementsDistillation = data.achivementsDistillation as string | undefined;
     
     if (!danceStructureDistillation || !currentSectionName || !performanceDistillation || !performanceHistoryDistillation) {
         const missingParameters = [
@@ -31,6 +32,7 @@ export async function POST(event: RequestEvent) {
         currentSectionName,
         performanceDistillation,
         performanceHistoryDistillation,
+        achivementsDistillation,
     );
 
     return json(feedbackData);

--- a/svelte-web-frontend/src/routes/styles.scss
+++ b/svelte-web-frontend/src/routes/styles.scss
@@ -191,6 +191,9 @@ a.button {
 .p-1 {
 	padding: 0.25em;
 }
+.mt-1 {
+	margin-top: 0.25em;
+}
 
 .margin-auto {
 	margin: auto;


### PR DESCRIPTION
This PR adds achievements that are computed based on performance history.

Right now, we only report achievements for when the user has achieved a certain number of practice attempts (for both individual sections of the song as well as accumulated across all sections).

This also fixes some layout bugs for the terminal feedback screen that appear on smaller screen sizes. It also rearranges UI elements on the terminal feedback screen.

![Screen Shot 2023-10-18 at 15 27 55](https://github.com/j55blanchet/dance-teacher-xr-unity/assets/4062772/1f82b0a9-c38c-4c55-95e0-6b01465b25fd)


