### PR TITLE
Julien/joint emphasis fix

### DIFF
--- a/svelte-web-frontend/src/lib/ai/feedback.ts
+++ b/svelte-web-frontend/src/lib/ai/feedback.ts
@@ -108,12 +108,13 @@ export async function generateFeedbackWithClaudeLLM(
     dancePerformanceHistory: FrontendDancePeformanceHistory | undefined,
     mediumScoreThreshold: number,
     goodScoreThreshold: number,
+    badJointSDThreshold: number,
     attemptHistory: { date: Date, score: number, segmentId: string }[],
 ): Promise<TerminalFeedback> {
 
     const danceStructureDistillation = danceTree ? distillDanceTreeStructureToTextualRepresentation(danceTree): undefined;
     const danceStructureDistillationIsMissing = danceStructureDistillation === undefined;
-    const performanceDistillation = performance ? distillFrontendPerformanceSummaryToTextualRepresentation(performance, mediumScoreThreshold, goodScoreThreshold) : undefined;
+    const performanceDistillation = performance ? distillFrontendPerformanceSummaryToTextualRepresentation(performance, mediumScoreThreshold, goodScoreThreshold, badJointSDThreshold) : undefined;
     const performanceDistillationIsMissing = performanceDistillation === undefined;
     const performanceHistoryDistillation = dancePerformanceHistory ? distillPerformanceHistoryToTextualRepresentation(dancePerformanceHistory) : undefined;
     const performanceHistoryDistillationIsMissing = performanceHistoryDistillation === undefined;

--- a/svelte-web-frontend/src/lib/model/settings.ts
+++ b/svelte-web-frontend/src/lib/model/settings.ts
@@ -17,6 +17,7 @@ const DEFAULT_SETTINGS = {
    summaryFeedback_skeleton3d_mediumPerformanceThreshold: 0.8,
    summaryFeedback_skeleton3d_goodPerformanceThreshold: 0.9,
    evaluation_summarizeSubsections: 'allnodes' as const,
+   metric__3dskeletonsimilarity__badJointStdDeviationThreshold: 1.5,
    danceVideoVolume: 0.5,
 }
 
@@ -71,6 +72,7 @@ export const evaluation_summarizeSubsectionsOptions = {
 export const evaluation_summarizeSubsections = createOptionsSettingsStore(
     "evaluation_analyzeSubsections", DEFAULT_SETTINGS.evaluation_summarizeSubsections, evaluation_summarizeSubsectionsOptions
 );
+export const metric__3dskeletonsimilarity__badJointStdDeviationThreshold = createNumberSettingsStore("metric__3dskeletonsimilarity__badJointStdDeviationThreshold", DEFAULT_SETTINGS.metric__3dskeletonsimilarity__badJointStdDeviationThreshold);
 export const summaryFeedback_skeleton3d_mediumPerformanceThreshold = createNumberSettingsStore("summaryFeedback_skeleton3d_mediumPerformanceThreshold", DEFAULT_SETTINGS.summaryFeedback_skeleton3d_mediumPerformanceThreshold);
 export const summaryFeedback_skeleton3d_goodPerformanceThreshold = createNumberSettingsStore("summaryFeedback_skeleton3d_goodPerformanceThreshold", DEFAULT_SETTINGS.summaryFeedback_skeleton3d_goodPerformanceThreshold);
 export const danceVideoVolume = createNumberSettingsStore("danceVideoVolume", DEFAULT_SETTINGS.danceVideoVolume);    
@@ -93,5 +95,6 @@ export function resetSettingsToDefault() {
     summaryFeedback_skeleton3d_mediumPerformanceThreshold.set(DEFAULT_SETTINGS.summaryFeedback_skeleton3d_mediumPerformanceThreshold);
     summaryFeedback_skeleton3d_goodPerformanceThreshold.set(DEFAULT_SETTINGS.summaryFeedback_skeleton3d_goodPerformanceThreshold);
     evaluation_summarizeSubsections.set(DEFAULT_SETTINGS.evaluation_summarizeSubsections)
+    metric__3dskeletonsimilarity__badJointStdDeviationThreshold.set(DEFAULT_SETTINGS.metric__3dskeletonsimilarity__badJointStdDeviationThreshold);
     danceVideoVolume.set(DEFAULT_SETTINGS.danceVideoVolume)
 }

--- a/svelte-web-frontend/src/lib/pages/PracticePage.svelte
+++ b/svelte-web-frontend/src/lib/pages/PracticePage.svelte
@@ -463,7 +463,7 @@ async function startCountdown() {
             webcamRecordedChunks.push(e.data);
         });
         webcamRecorder.addEventListener('stop', () => {
-            let recordedVideoURL = URL.createObjectURL(new Blob(webcamRecordedChunks));
+            let recordedVideoURL = URL.createObjectURL(new Blob(webcamRecordedChunks, {type: webcamRecorderMimeType}));
             resolveWebcamRecordedObjectUrl?.(recordedVideoURL);
         });
         webcamRecorder.start();

--- a/svelte-web-frontend/src/lib/pages/PracticePage.svelte
+++ b/svelte-web-frontend/src/lib/pages/PracticePage.svelte
@@ -3,7 +3,7 @@ export type PracticePageState = "waitWebcam" | "waitStart" | 'waitStartUserInter
 export const INITIAL_STATE: PracticePageState = "waitWebcam";
 </script>
 <script lang="ts">
-import { danceVideoVolume, debugMode__addPlaceholderAchievement, practicePage__enablePerformanceRecording } from './../model/settings';
+import { danceVideoVolume, debugMode__addPlaceholderAchievement, metric__3dskeletonsimilarity__badJointStdDeviationThreshold, practicePage__enablePerformanceRecording } from './../model/settings';
 import { v4 as generateUUIDv4 } from 'uuid';
 import { evaluation_summarizeSubsections, practiceFallbackPlaybackSpeed, summaryFeedback_skeleton3d_mediumPerformanceThreshold, summaryFeedback_skeleton3d_goodPerformanceThreshold } from '$lib/model/settings';
 // import { replaceJSONForStringifyDisplay } from '$lib/utils/formatting';
@@ -248,6 +248,7 @@ async function getFeedback(performanceSummary: FrontendPerformanceSummary | null
                 dancePerfHistory ?? undefined,
                 $summaryFeedback_skeleton3d_mediumPerformanceThreshold,
                 $summaryFeedback_skeleton3d_goodPerformanceThreshold,
+                $metric__3dskeletonsimilarity__badJointStdDeviationThreshold,
                 attemptHistory,
             )
         } catch(e) {

--- a/svelte-web-frontend/src/lib/pages/SettingsPage.svelte
+++ b/svelte-web-frontend/src/lib/pages/SettingsPage.svelte
@@ -18,6 +18,7 @@ import {
     useAIFeedback,
     evaluation_summarizeSubsections,
     evaluation_summarizeSubsectionsOptions,
+    metric__3dskeletonsimilarity__badJointStdDeviationThreshold,
 	useTextToSpeech,
 	practiceFallbackPlaybackSpeed,
     practicePage__enablePerformanceRecording,
@@ -93,14 +94,6 @@ function clearPerformanceHistory() {
             <label for="debugPauseDuration">Debug Pause Duration</label>
             <input class="outlined thin" type="number" name="debugPauseDuration" bind:value={$debugPauseDurationSecs} min={pauseDurationMin} max={pauseDurationMax} step={pauseDurationStep}>
         </div>
-        <div>
-            <label for="feedback_YellowThreshold">Live Feedback - Yellow Threshold</label>
-            <input class="outlined thin" type="number" name="feedback_YellowThreshold" bind:value={$feedback_YellowThreshold} min={qijiaScoreMin} max={qijiaScoreMax} step={0.1}>
-        </div>
-        <div>
-            <label for="feedback_GreenThreshold">Live Feedback - Green Threshold</label>
-            <input class="outlined thin" type="number" name="feedback_GreenThreshold" bind:value={$feedback_GreenThreshold} min={qijiaScoreMin} max={qijiaScoreMax} step={0.1}>
-        </div>
         {/if}
         <div>
             <label for="practicePage__enablePerformanceRecording">Record Performances</label>
@@ -128,14 +121,6 @@ function clearPerformanceHistory() {
             <input class="outlined thin" type="number" name="evaluation_GoodBadTrialThreshold" disabled={$useAIFeedback} bind:value={$evaluation_GoodBadTrialThreshold} min={qijiaScoreMin} max={qijiaScoreMax} step={0.1}>
         </div>
         <div>
-            <label for="summaryFeedback_skeleton3d_mediumPerformanceThreshold">3D Angle - Yellow Threshold</label>
-            <input class="outlined thin" type="number" name="summaryFeedback_skeleton3d_mediumPerformanceThreshold" bind:value={$summaryFeedback_skeleton3d_mediumPerformanceThreshold} min={0} max={1} step={0.01}>
-        </div>
-        <div>
-            <label for="summaryFeedback_skeleton3d_goodPerformanceThreshold">3D Angle - Green Threshold</label>
-            <input class="outlined thin" type="number" name="summaryFeedback_skeleton3d_goodPerformanceThreshold" bind:value={$summaryFeedback_skeleton3d_goodPerformanceThreshold} min={0} max={1} step={0.01}>
-        </div>
-        <div>
             <label for="evaluation_summarizeSubsections">Evaluate Subsections</label>
             <select class="outlined thin" name="evaluation_summarizeSubsections" bind:value={$evaluation_summarizeSubsections}>
                 {#each Object.entries(evaluation_summarizeSubsectionsOptions) as [optionValue, optionTitle]}
@@ -143,6 +128,42 @@ function clearPerformanceHistory() {
                 {/each}
             </select>
         </div>
+    </div>
+    <div class="group">
+        <h3>Metrics Parameters</h3>
+        <details>
+            <summary>3D Skeleton Joint Angle Similarity</summary>
+            <div class="controlGrid">
+                <label for="metric__3dskeletonsimilarity__badJointStdDeviationThreshold">'Troublsome Joint' Threshold</label>
+                <input class="outlined thin" type="number" name="summaryFeedback_skeleton3d_mediumPerformanceThreshold" bind:value={$metric__3dskeletonsimilarity__badJointStdDeviationThreshold} min={0} max={3.0} step={0.05}>
+                <span class="note">
+                    Used to determine which joints get 
+                    reported to the LLM as "troublesome joints"
+                </span>
+
+                <label for="summaryFeedback_skeleton3d_mediumPerformanceThreshold">3D Angle - Yellow Threshold</label>
+                <input class="outlined thin" type="number" name="summaryFeedback_skeleton3d_mediumPerformanceThreshold" bind:value={$summaryFeedback_skeleton3d_mediumPerformanceThreshold} min={0} max={1} step={0.01}>
+                <span class="note">This is used for bar coloring</span>
+
+                <label for="summaryFeedback_skeleton3d_goodPerformanceThreshold">3D Angle - Green Threshold</label>
+                <input class="outlined thin" type="number" name="summaryFeedback_skeleton3d_goodPerformanceThreshold" bind:value={$summaryFeedback_skeleton3d_goodPerformanceThreshold} min={0} max={1} step={0.01}>
+                <span class="note">This is used for bar coloring</span>
+            </div>
+        </details>
+        <details>
+            <summary>2D Skeleton Vector Similarity (Qijia's Method)</summary>
+            <div class="controlGrid">
+                
+                
+                <label for="feedback_YellowThreshold">Yellow Threshold</label>
+                <input class="outlined thin" type="number" name="feedback_YellowThreshold" bind:value={$feedback_YellowThreshold} min={qijiaScoreMin} max={qijiaScoreMax} step={0.1}>
+                <span class="note">This is used for live feedback color coding</span>
+
+                <label for="feedback_GreenThreshold">Green Threshold</label>
+                <input class="outlined thin" type="number" name="feedback_GreenThreshold" bind:value={$feedback_GreenThreshold} min={qijiaScoreMin} max={qijiaScoreMax} step={0.1}>
+                <span class="note">This is used for live feedback color coding</span>
+            </div>
+        </details>
     </div>
     <div>
         <button class="button" disabled={Object.keys($frontendPerformanceHistory).length === 0} on:click={clearPerformanceHistory}>Clear Performance History</button>
@@ -184,11 +205,53 @@ div.group {
 }
 
 
-div.group > div {
+div.group > div, details > div {
     display: flex;
     flex-direction: row;
     align-items: center;
     gap: 0.5rem;
+}
+
+details {
+    margin: 0.5em auto;
+    text-align: center;
+}
+
+details summary {
+    cursor: pointer;
+
+    &:hover {
+        text-decoration: underline;
+    }
+}
+
+.note {
+    font-size: 0.8em;
+    color: gray;
+    margin-top: -0.6em;
+    margin-bottom: 0.25em;
+    white-space: pre-line;
+}  
+
+.controlGrid {
+    font-size: 0.8em;
+    margin: 0.5em auto;
+    display: inline-grid;
+    grid-template-columns: auto 1fr;
+}
+
+.controlGrid label {
+    grid-column: 1;
+    justify-self: flex-end;
+    align-self: center;
+}
+.controlGrid input {
+    grid-column: 2;
+    justify-self: flex-start;
+    align-self: center;
+}
+.controlGrid .note {
+    grid-column: 1 / span 2;
 }
 
 input[type=number] {


### PR DESCRIPTION
* Alters textual distillation of dance performance to compare the joints to the dance mean + std deviation, rather than always reporting the worst one.
* Now returns a list of "troublesome" joint angles, rather than always returning the worst one. This list can have 0 items if non are below the threshold.
* Helps reduce the frequency of "open up your left elbow feedback".

* Also, fixes review page bug on safari.