### PR TITLE
Adding User Choice for Practice Configuration 

### DIFF
--- a/svelte-web-frontend/src/lib/ai/SkeletonFeedbackVisualization.ts
+++ b/svelte-web-frontend/src/lib/ai/SkeletonFeedbackVisualization.ts
@@ -42,7 +42,7 @@ function getVectorColor(lmData: LandmarkData, evaluationResult: FrontendLiveEval
     return 'red';
 }
 
-export function DrawColorCodedSkeleton(
+export function Draw2dSkeleton(
     ctx: CanvasRenderingContext2D, 
     pose: null | NormalizedLandmark[], 
     evaluationResult: FrontendLiveEvaluationResult | null,

--- a/svelte-web-frontend/src/lib/ai/TeachingAgent.ts
+++ b/svelte-web-frontend/src/lib/ai/TeachingAgent.ts
@@ -7,15 +7,17 @@ import type { PracticeInterfaceModeKey } from '$lib/model/PracticeActivity';
 //     // similarityByNode: Map<DanceTreeNode["id"], number>;
 // }
 
-export function GeneratePracticeActivity(opts: {
+export type GeneratePracticeActivityParams = {
     dance: Dance,
     danceTree: DanceTree,
     danceTreeNode: DanceTreeNode,
-    playbackSpeed: number | 'default',
+    playbackSpeed: number,
     interfaceMode: PracticeInterfaceModeKey,
     terminalFeedbackEnabled: boolean,
-    enableUserSkeletonColorCoding: boolean,
-}) {
+    userSkeletonColorCodingEnabled: boolean,
+};
+
+export function GeneratePracticeActivity(opts: GeneratePracticeActivityParams) {
     
     const danceTreeSlug =  makeDanceTreeSlug(opts.danceTree);
     return {
@@ -24,14 +26,14 @@ export function GeneratePracticeActivity(opts: {
             startTime: opts.danceTreeNode.start_time,
             endTime: opts.danceTreeNode.end_time,
             interfaceMode: opts.interfaceMode,
-            terminalFeedbackEnabled: true,
-            enableUserSkeletonColorCoding: opts.enableUserSkeletonColorCoding,
+            terminalFeedbackEnabled: opts.terminalFeedbackEnabled,
+            userSkeletonColorCodingEnabled: opts.userSkeletonColorCodingEnabled,
             playbackSpeed: opts.playbackSpeed,
             dance: opts.dance,
             danceTree: opts.danceTree,
             danceTreeNode: opts.danceTreeNode,
         },
-        url: `/teachlesson/${danceTreeSlug}/practicenode/${opts.danceTreeNode.id}?playbackSpeed=${opts.playbackSpeed}&interfaceMode=${opts.interfaceMode}&terminalFeedbackEnabled=${opts.terminalFeedbackEnabled}`,
+        url: `/teachlesson/${danceTreeSlug}/practicenode/${opts.danceTreeNode.id}?playbackSpeed=${opts.playbackSpeed}&interfaceMode=${opts.interfaceMode}&terminalFeedbackEnabled=${opts.terminalFeedbackEnabled}&userSkeletonColorCodingEnabled=${opts.userSkeletonColorCodingEnabled}`,
     }
 }
 

--- a/svelte-web-frontend/src/lib/ai/TeachingAgent.ts
+++ b/svelte-web-frontend/src/lib/ai/TeachingAgent.ts
@@ -1,26 +1,53 @@
-import type { Dance, DanceTree, DanceTreeNode } from '../data/dances-store'
+import { makeDanceTreeSlug, type Dance, type DanceTree, type DanceTreeNode } from '../data/dances-store'
 import type PracticeActivity from '$lib/model/PracticeActivity';
+import type { PracticeInterfaceModeKey } from '$lib/model/PracticeActivity';
 
 // export interface UserDancePerformanceLog {
 //     // markingByNode: Map<DanceTreeNode["id"], number>;
 //     // similarityByNode: Map<DanceTreeNode["id"], number>;
 // }
 
-export function GeneratePracticeActivity(
+export function GeneratePracticeActivity(opts: {
     dance: Dance,
     danceTree: DanceTree,
     danceTreeNode: DanceTreeNode,
     playbackSpeed: number | 'default',
-    // userDancePerformanceLog: UserDancePerformanceLog
-): PracticeActivity {
+    interfaceMode: PracticeInterfaceModeKey,
+    terminalFeedbackEnabled: boolean,
+    enableUserSkeletonColorCoding: boolean,
+}) {
+    
+    const danceTreeSlug =  makeDanceTreeSlug(opts.danceTree);
     return {
-        segmentDescription: danceTreeNode.id,
-        startTime: danceTreeNode.start_time,
-        endTime: danceTreeNode.end_time,
-        activityTypes: ['drill'], // 'watch', 'mark', 'drill', 'fullout']
-        playbackSpeed,
-        dance,
-        danceTree,
-        danceTreeNode,
+        activity: {
+            segmentDescription: opts.danceTreeNode.id,
+            startTime: opts.danceTreeNode.start_time,
+            endTime: opts.danceTreeNode.end_time,
+            interfaceMode: opts.interfaceMode,
+            terminalFeedbackEnabled: true,
+            enableUserSkeletonColorCoding: opts.enableUserSkeletonColorCoding,
+            playbackSpeed: opts.playbackSpeed,
+            dance: opts.dance,
+            danceTree: opts.danceTree,
+            danceTreeNode: opts.danceTreeNode,
+        },
+        url: `/teachlesson/${danceTreeSlug}/practicenode/${opts.danceTreeNode.id}?playbackSpeed=${opts.playbackSpeed}&interfaceMode=${opts.interfaceMode}&terminalFeedbackEnabled=${opts.terminalFeedbackEnabled}`,
     }
 }
+
+
+// {
+//     referenceVideo: {
+//         visibility: 'visible',
+//         skeleton: 'none',
+//         userCanToggleOnOff: false,
+//         skeletonColorCoding: false,
+//     },
+//     userVideo: {
+//         visibility: 'visible',
+//         skeleton: 'user',
+//         userCanToggleOnOff: false,
+//         skeletonColorCoding: true,
+//     },
+//     terminalFeedback: 'enabled',
+// },

--- a/svelte-web-frontend/src/lib/ai/TeachingAgent.ts
+++ b/svelte-web-frontend/src/lib/ai/TeachingAgent.ts
@@ -12,7 +12,7 @@ export type GeneratePracticeActivityOptions = {
     playbackSpeed: number,
     interfaceMode: PracticeInterfaceModeKey,
     terminalFeedbackEnabled: boolean,
-    userSkeletonColorCodingEnabled: boolean,
+    showUserSkeleton: boolean,
 };
 
 export function GeneratePracticeActivity(
@@ -30,13 +30,13 @@ export function GeneratePracticeActivity(
             endTime: danceTreeNode.end_time,
             interfaceMode: opts.interfaceMode,
             terminalFeedbackEnabled: opts.terminalFeedbackEnabled,
-            userSkeletonColorCodingEnabled: opts.userSkeletonColorCodingEnabled,
+            showUserSkeleton: opts.showUserSkeleton,
             playbackSpeed: opts.playbackSpeed,
             dance: dance,
             danceTree: danceTree,
             danceTreeNode: danceTreeNode,
         },
-        url: `/teachlesson/${danceTreeSlug}/practicenode/${danceTreeNode.id}?playbackSpeed=${opts.playbackSpeed}&interfaceMode=${opts.interfaceMode}&terminalFeedbackEnabled=${opts.terminalFeedbackEnabled}&userSkeletonColorCodingEnabled=${opts.userSkeletonColorCodingEnabled}`,
+        url: `/teachlesson/${danceTreeSlug}/practicenode/${danceTreeNode.id}?playbackSpeed=${opts.playbackSpeed}&interfaceMode=${opts.interfaceMode}&terminalFeedbackEnabled=${opts.terminalFeedbackEnabled}&showUserSkeleton=${opts.showUserSkeleton}`,
     }
 }
 

--- a/svelte-web-frontend/src/lib/ai/TeachingAgent.ts
+++ b/svelte-web-frontend/src/lib/ai/TeachingAgent.ts
@@ -7,33 +7,36 @@ import type { PracticeInterfaceModeKey } from '$lib/model/PracticeActivity';
 //     // similarityByNode: Map<DanceTreeNode["id"], number>;
 // }
 
-export type GeneratePracticeActivityParams = {
-    dance: Dance,
-    danceTree: DanceTree,
-    danceTreeNode: DanceTreeNode,
+
+export type GeneratePracticeActivityOptions = {
     playbackSpeed: number,
     interfaceMode: PracticeInterfaceModeKey,
     terminalFeedbackEnabled: boolean,
     userSkeletonColorCodingEnabled: boolean,
 };
 
-export function GeneratePracticeActivity(opts: GeneratePracticeActivityParams) {
+export function GeneratePracticeActivity(
+    dance: Dance,
+    danceTree: DanceTree,
+    danceTreeNode: DanceTreeNode,
+    opts: GeneratePracticeActivityOptions
+) {
     
-    const danceTreeSlug =  makeDanceTreeSlug(opts.danceTree);
+    const danceTreeSlug =  makeDanceTreeSlug(danceTree);
     return {
         activity: {
-            segmentDescription: opts.danceTreeNode.id,
-            startTime: opts.danceTreeNode.start_time,
-            endTime: opts.danceTreeNode.end_time,
+            segmentDescription: danceTreeNode.id,
+            startTime: danceTreeNode.start_time,
+            endTime: danceTreeNode.end_time,
             interfaceMode: opts.interfaceMode,
             terminalFeedbackEnabled: opts.terminalFeedbackEnabled,
             userSkeletonColorCodingEnabled: opts.userSkeletonColorCodingEnabled,
             playbackSpeed: opts.playbackSpeed,
-            dance: opts.dance,
-            danceTree: opts.danceTree,
-            danceTreeNode: opts.danceTreeNode,
+            dance: dance,
+            danceTree: danceTree,
+            danceTreeNode: danceTreeNode,
         },
-        url: `/teachlesson/${danceTreeSlug}/practicenode/${opts.danceTreeNode.id}?playbackSpeed=${opts.playbackSpeed}&interfaceMode=${opts.interfaceMode}&terminalFeedbackEnabled=${opts.terminalFeedbackEnabled}&userSkeletonColorCodingEnabled=${opts.userSkeletonColorCodingEnabled}`,
+        url: `/teachlesson/${danceTreeSlug}/practicenode/${danceTreeNode.id}?playbackSpeed=${opts.playbackSpeed}&interfaceMode=${opts.interfaceMode}&terminalFeedbackEnabled=${opts.terminalFeedbackEnabled}&userSkeletonColorCodingEnabled=${opts.userSkeletonColorCodingEnabled}`,
     }
 }
 

--- a/svelte-web-frontend/src/lib/ai/UserDanceEvaluator.ts
+++ b/svelte-web-frontend/src/lib/ai/UserDanceEvaluator.ts
@@ -204,21 +204,28 @@ export default class UserDanceEvaluator<
         const summaryMetricKeys = Object.keys(this.summaryMetrics) as (keyof U)[];
         const summaryMetricResults = Object.fromEntries(summaryMetricKeys.map((summaryMetricKey) => {
             const metric = this.summaryMetrics[summaryMetricKey];
-            const metricSummary = (metric).summarizeMetric(
-                trackHistory,
-            )
-            if (this.performanceHistoryStore) {
-                const formattedSummary = metric.formatSummary(metricSummary as any);
-                this.performanceHistoryStore.recordPerformance(
-                    track.danceRelativeStem,
-                    sectionName,
-                    summaryMetricKey,
-                    formattedSummary as any,
-                    partOfLargerPerformance
+            let metricSummaryResult = undefined;
+            try {
+                const metricSummary = (metric).summarizeMetric(
+                    trackHistory,
                 )
+                metricSummaryResult = metricSummary;
+                if (this.performanceHistoryStore) {
+                    const formattedSummary = metric.formatSummary(metricSummary as any);
+                    this.performanceHistoryStore.recordPerformance(
+                        track.danceRelativeStem,
+                        sectionName,
+                        summaryMetricKey,
+                        formattedSummary as any,
+                        partOfLargerPerformance
+                    )
+                }
+            } catch(e) {
+                console.warn(`Unable to summarize metric ${String(summaryMetricKey)} for section ${sectionName}${partOfLargerPerformance ? ' as part of a larger performance.': ''}`, e);
             }
-            return [summaryMetricKey, metricSummary]
-        })) as {[K in keyof U]: ReturnType<U[K]["summarizeMetric"]>};
+            
+            return [summaryMetricKey, metricSummaryResult]
+        })) as {[K in keyof U]: ReturnType<U[K]["summarizeMetric"]> | undefined};
 
         return {
             ...liveMetricSummaryResults,

--- a/svelte-web-frontend/src/lib/ai/UserDanceEvaluator.ts
+++ b/svelte-web-frontend/src/lib/ai/UserDanceEvaluator.ts
@@ -221,7 +221,7 @@ export default class UserDanceEvaluator<
                     )
                 }
             } catch(e) {
-                console.warn(`Unable to summarize metric ${String(summaryMetricKey)} for section ${sectionName}${partOfLargerPerformance ? ' as part of a larger performance.': ''}`, e);
+                console.error(`Unable to summarize metric ${String(summaryMetricKey)} for section ${sectionName}${partOfLargerPerformance ? ' as part of a larger performance.': ''}`, e);
             }
             
             return [summaryMetricKey, metricSummaryResult]

--- a/svelte-web-frontend/src/lib/ai/feedback.ts
+++ b/svelte-web-frontend/src/lib/ai/feedback.ts
@@ -8,9 +8,10 @@ import { evaluation_GoodBadTrialThreshold } from "$lib/model/settings";
 import { ComparisonVectorToTerminalFeedbackBodyPartMap, QijiaMethodComparisionVectorNamesToIndexMap } from "./EvaluationCommonUtils";
 import type { FrontendPerformanceSummary } from "./FrontendDanceEvaluator";
 import { distillDanceTreeStructureToTextualRepresentation, distillFrontendPerformanceSummaryToTextualRepresentation, distillPerformanceHistoryToTextualRepresentation } from "./textual-distillation";
-import { getRandomBadTrialHeadline, getRandomGoodTrialHeadline } from "./precomputed-feedback-msgs";
+import { getRandomBadTrialHeadline, getRandomGoodTrialHeadline, getRandomNoFeedbackHeadline } from "./precomputed-feedback-msgs";
 import type { FrontendDancePeformanceHistory } from "./frontendPerformanceHistory";
 import detectAchievements from "./detectAchievements";
+import { get } from "svelte/store";
 
 // Variable to store the value of the evaluation threshold, initialized to 1.0
 let evaluation_GoodBadTrialThresholdValue = 1.0;
@@ -18,6 +19,29 @@ let evaluation_GoodBadTrialThresholdValue = 1.0;
 evaluation_GoodBadTrialThreshold.subscribe((value) => {
     evaluation_GoodBadTrialThresholdValue = value;
 });
+
+export function generateFeedbackNoPerformance(
+    danceRelativeStem: string,
+    dancePerformanceHistory: FrontendDancePeformanceHistory | undefined,
+    currentSectionName: string,
+ ): TerminalFeedback {
+
+    let achievements = [] as string[];
+    if (currentSectionName && dancePerformanceHistory) {
+        achievements = detectAchievements({
+            attemptedNodeId: currentSectionName,
+            performanceHistory: dancePerformanceHistory,
+            outputTarget: 'user',
+        });
+    }
+
+    return {
+        headline: getRandomNoFeedbackHeadline(),
+        paragraphs: ['Would you like to do that again or try something else?'],
+        achievements: achievements,
+        suggestedAction: 'repeat',
+    }
+}
 
 /**
  * Generates feedback for the user using simple rule-based approach. This can be computed locally,

--- a/svelte-web-frontend/src/lib/ai/feedback.ts
+++ b/svelte-web-frontend/src/lib/ai/feedback.ts
@@ -108,12 +108,13 @@ export async function generateFeedbackWithClaudeLLM(
     dancePerformanceHistory: FrontendDancePeformanceHistory | undefined,
     mediumScoreThreshold: number,
     goodScoreThreshold: number,
+    badJointSDThreshold: number,
     attemptHistory: { date: Date, score: number, segmentId: string }[],
 ): Promise<TerminalFeedback> {
 
     const danceStructureDistillation = danceTree ? distillDanceTreeStructureToTextualRepresentation(danceTree): undefined;
     const danceStructureDistillationIsMissing = danceStructureDistillation === undefined;
-    const performanceDistillation = performance ? distillFrontendPerformanceSummaryToTextualRepresentation(performance, mediumScoreThreshold, goodScoreThreshold) : undefined;
+    const performanceDistillation = performance ? distillFrontendPerformanceSummaryToTextualRepresentation(performance, mediumScoreThreshold, goodScoreThreshold, badJointSDThreshold) : undefined;
     const performanceDistillationIsMissing = performanceDistillation === undefined;
     const performanceHistoryDistillation = dancePerformanceHistory ? distillPerformanceHistoryToTextualRepresentation(dancePerformanceHistory) : undefined;
     const performanceHistoryDistillationIsMissing = performanceHistoryDistillation === undefined;

--- a/svelte-web-frontend/src/lib/ai/performanceHistory.ts
+++ b/svelte-web-frontend/src/lib/ai/performanceHistory.ts
@@ -106,7 +106,7 @@ export function createPerformanceHistoryStore<MetricTypes extends Record<string,
                 return attempts;
             });
         },
-        lastNAttempts<T extends keyof MetricTypes>(danceRelativeStem: string, metricName: T, n: number) {
+        lastNAttempts<T extends keyof MetricTypes>(danceRelativeStem: string, metricName: T, n?: number) {
             return derived(this, ($history) => {
                 if (!$history) return [];
                 const danceHistory = $history[danceRelativeStem] ?? {};
@@ -130,7 +130,11 @@ export function createPerformanceHistoryStore<MetricTypes extends Record<string,
 
                 // Sort attempts - most recent first
                 attempts.sort((a, b) => b.date.getTime() - a.date.getTime());
-                return attempts.slice(-n);
+
+                if (n !== undefined) {
+                    return attempts.slice(-n);    
+                }
+                return attempts;
             });
         },
 

--- a/svelte-web-frontend/src/lib/ai/performanceHistory.ts
+++ b/svelte-web-frontend/src/lib/ai/performanceHistory.ts
@@ -38,6 +38,8 @@ function loadPerformanceHistoryFromLocalstorage<MetricTypes extends Record<strin
     }
 }
 
+let a =  writable(0);
+
 export function createPerformanceHistoryStore<MetricTypes extends Record<string, BaseMetric<any, any>>>() {
 	const { subscribe, update } = writable(loadPerformanceHistoryFromLocalstorage() as CompletePerformanceHistory<MetricTypes>);
 

--- a/svelte-web-frontend/src/lib/ai/precomputed-feedback-msgs.ts
+++ b/svelte-web-frontend/src/lib/ai/precomputed-feedback-msgs.ts
@@ -18,8 +18,13 @@ const GoodTrialHeadlines = Object.freeze([
     "You're a Pro!",
     "Outstanding Performance!"
 ])
+let lastGoodTrialHeadlineIndex = -1;
 export function getRandomGoodTrialHeadline() {
-    return GoodTrialHeadlines[Math.floor(Math.random() * GoodTrialHeadlines.length)]
+    let index = lastGoodTrialHeadlineIndex;
+    while (index === lastGoodTrialHeadlineIndex) {
+        index = Math.floor(Math.random() * GoodTrialHeadlines.length)
+    }
+    return GoodTrialHeadlines[index];
 }
 
 // Headlines for feedback when the user didn't do particularly well (and should try again).
@@ -46,6 +51,28 @@ const BadTrialHeadline = Object.freeze([
     "Stay Tenacious!"
 ])
 
+let lastBadTrialHeadlineIndex = -1;
 export function getRandomBadTrialHeadline() {
-    return BadTrialHeadline[Math.floor(Math.random() * BadTrialHeadline.length)]
+    let index = lastBadTrialHeadlineIndex;
+    while (index === lastBadTrialHeadlineIndex) {
+        index = Math.floor(Math.random() * BadTrialHeadline.length)
+    }
+    return BadTrialHeadline[index];
+}
+
+
+const NoFeedbackHeadlines = Object.freeze([
+    "What next?",
+    "What are you thinking now?",
+    "What do you think?",
+    "How did you feel?",
+])
+
+let lastNoFeedbackHeadlineIndex = -1;
+export function getRandomNoFeedbackHeadline() {
+    let index = lastNoFeedbackHeadlineIndex;
+    while (index === lastNoFeedbackHeadlineIndex) {
+        index = Math.floor(Math.random() * NoFeedbackHeadlines.length)
+    }
+    return NoFeedbackHeadlines[index];
 }

--- a/svelte-web-frontend/src/lib/elements/DanceTreeVisual.svelte
+++ b/svelte-web-frontend/src/lib/elements/DanceTreeVisual.svelte
@@ -2,7 +2,8 @@
 export type NodeHighlight = {
     color?: string,
     label?: string,
-    pulse?: boolean
+    pulse?: boolean,
+    borderColor?: string,
 }
 </script>
 <script lang="ts">
@@ -164,12 +165,14 @@ function barClicked () {
        class:hasBadScore={enableThisNodeColorCoding && $bestScore !== undefined && $bestScore.score <= $summaryFeedback_skeleton3d_mediumPerformanceThreshold}
        class:highlighted={highlight !== undefined}
        class:highlighted-pulse={highlight?.pulse ?? false}
+       class:highlighted-colorborder={highlight?.borderColor !== undefined}
        class:labeled={highlight?.label !== undefined}
+       style:--highlight-color={highlight?.color ?? 'var(--color-theme-1'}
+       style:--custom-border-color={highlight?.borderColor ?? 'var(--color-text)'}
        on:click={barClicked}
        role="menuitem"
        tabindex="0"
        title={nodeTitleString}
-       style="--highlight-color: {highlight?.color ?? 'var(--color-theme-1)'};"
     >   
         {#if showProgress}<span class="progress" style="width:{progressPercent*100}%">
             <!-- {currentTime.toFixed(1)} -->
@@ -213,7 +216,7 @@ function barClicked () {
 
 .node {
     --hide-transition-duration: 0.75s;
-    --highlight-color: #eaff00;
+    --highlight-color: #eaff00;    
 }
     
     .bar {
@@ -223,7 +226,7 @@ function barClicked () {
         // min-width: 100%;
         text-align: center;
         min-height: 1.25em;
-        transition: height var(--hide-transition-duration) ease-in-out, width var(--hide-transition-duration) ease-in-out, padding var(--hide-transition-duration) ease-in-out, opacity var(--hide-transition-duration) ease-in-out, background-color var(--hide-transition-duration) ease-in-out;
+        transition: height var(--height-transition-duration, --hide-transition-duration) ease-in-out, width var(--hide-transition-duration) ease-in-out, padding var(--hide-transition-duration) ease-in-out, opacity var(--hide-transition-duration) ease-in-out, background-color var(--hide-transition-duration) ease-in-out;
         border-width: 0.12em;
         padding: 0;
         overflow: hidden;
@@ -245,6 +248,10 @@ function barClicked () {
         animation-duration: 0.5s;
         animation-iteration-count: infinite;
         animation-direction: alternate;
+    }
+
+    .bar.highlighted-colorborder {
+        border-color: var(--custom-border-color);
     }
     // .bar .label {
     //     // color: var(--highlight-color);

--- a/svelte-web-frontend/src/lib/elements/DanceTreeVisual.svelte
+++ b/svelte-web-frontend/src/lib/elements/DanceTreeVisual.svelte
@@ -222,7 +222,7 @@ function barClicked () {
         position: relative;
         // min-width: 100%;
         text-align: center;
-        min-height: 1em;
+        min-height: 1.25em;
         transition: height var(--hide-transition-duration) ease-in-out, width var(--hide-transition-duration) ease-in-out, padding var(--hide-transition-duration) ease-in-out, opacity var(--hide-transition-duration) ease-in-out, background-color var(--hide-transition-duration) ease-in-out;
         border-width: 0.12em;
         padding: 0;

--- a/svelte-web-frontend/src/lib/elements/PracticeActivityConfigurator.svelte
+++ b/svelte-web-frontend/src/lib/elements/PracticeActivityConfigurator.svelte
@@ -1,0 +1,104 @@
+<script lang="ts">
+import type { GeneratePracticeActivityOptions } from "$lib/ai/TeachingAgent";
+import { PracticeInterfaceModeOptions } from "$lib/model/PracticeActivity";
+import { practiceActivities__playbackSpeed, practiceActivities__userSkeletonColorCodingEnabled, practiceActivities__terminalFeedbackEnabled, practiceActivities__interfaceMode } from "$lib/model/settings";
+
+export let persistInSettings = false;
+export let practiceActivityParams: GeneratePracticeActivityOptions = {
+    playbackSpeed: $practiceActivities__playbackSpeed,
+    interfaceMode: $practiceActivities__interfaceMode,
+    terminalFeedbackEnabled: $practiceActivities__terminalFeedbackEnabled,
+    userSkeletonColorCodingEnabled: $practiceActivities__userSkeletonColorCodingEnabled,
+}
+
+$: {
+    if (persistInSettings) {
+        $practiceActivities__playbackSpeed = practiceActivityParams.playbackSpeed;
+        $practiceActivities__terminalFeedbackEnabled = practiceActivityParams.terminalFeedbackEnabled;
+        $practiceActivities__userSkeletonColorCodingEnabled = practiceActivityParams.userSkeletonColorCodingEnabled;
+    }
+}
+</script>
+
+<div class="practiceActivityConfigurator">
+    <div class="control">
+        <label for="playbackSpeed">Speed:</label>
+        <input type="range" name="playbackSpeed" bind:value={practiceActivityParams.playbackSpeed} min="0.4" max="1.3" step="0.1" />
+        {practiceActivityParams.playbackSpeed.toFixed(1)}x
+    </div>
+    <div class="control interfaceMode" >
+        {#each Object.entries(PracticeInterfaceModeOptions) as [modeOptionValue, modeOptionTitle]}
+        <label class="button outlined thin" class:selected={modeOptionValue === practiceActivityParams.interfaceMode }>
+            {modeOptionTitle}
+            <input type="radio" name="practiceActivityInterfaceMode" value={modeOptionValue} bind:group={practiceActivityParams.interfaceMode}/>
+        </label>
+        {/each}
+    </div>
+    <div class="control">
+        <label for="enableUserSkeletonColorCoding">Live Color Coding</label>
+        <input type="checkbox" name="enableUserSkeletonColorCoding" bind:checked={practiceActivityParams.userSkeletonColorCodingEnabled} />
+    </div>
+    <div class="control">
+        <label for="terminalFeedbackEnabled">Provide Feedback</label>
+        <input type="checkbox" name="terminalFeedbackEnabled" bind:checked={practiceActivityParams.terminalFeedbackEnabled} />
+    </div>
+</div>
+
+<style lang="scss">
+
+.practiceActivityConfigurator {
+    display: flex;
+    flex-direction: column;
+    // grid-template-rows: "label" auto "input" auto;
+    gap: 0.5rem;
+    margin: 0rem 0 1rem 0;
+    display: flex;
+}
+
+.control {
+    display: flex;
+    flex-direction: row; 
+    align-items: center;
+    justify-content: center;
+    gap: 1ch;
+
+    input[type="range"] {
+        max-width: 10ch;
+    }
+
+    &.interfaceMode label {
+        box-sizing: border-box;
+        padding: 0.25em;
+        width: 5em;
+        height: 5em;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        text-align: center;
+        // border-radius: var(--std-border-radius);
+        box-shadow: 2px 2px 2px 2px rgba(0, 0, 0, 0.3);
+
+        & input {
+            position:absolute;
+            left: -50%;
+            opacity: 0;
+            width: 0;
+            height: 0;
+
+        }
+
+        &:has( > input:checked) {
+            color: red;
+        }
+
+        &.selected {
+            color: var(--color-theme-1);
+            border-color: var(--color-theme-1);
+            border-width: 3px;
+            background: white;
+        }
+    }
+
+    // &.interfaceMode label:has(input[selected=true])
+}
+</style>

--- a/svelte-web-frontend/src/lib/elements/PracticeActivityConfigurator.svelte
+++ b/svelte-web-frontend/src/lib/elements/PracticeActivityConfigurator.svelte
@@ -1,21 +1,21 @@
 <script lang="ts">
 import type { GeneratePracticeActivityOptions } from "$lib/ai/TeachingAgent";
 import { PracticeInterfaceModeOptions } from "$lib/model/PracticeActivity";
-import { practiceActivities__playbackSpeed, practiceActivities__userSkeletonColorCodingEnabled, practiceActivities__terminalFeedbackEnabled, practiceActivities__interfaceMode } from "$lib/model/settings";
+import { practiceActivities__playbackSpeed, practiceActivities__showUserSkeleton, practiceActivities__terminalFeedbackEnabled, practiceActivities__interfaceMode } from "$lib/model/settings";
 
 export let persistInSettings = false;
 export let practiceActivityParams: GeneratePracticeActivityOptions = {
     playbackSpeed: $practiceActivities__playbackSpeed,
     interfaceMode: $practiceActivities__interfaceMode,
     terminalFeedbackEnabled: $practiceActivities__terminalFeedbackEnabled,
-    userSkeletonColorCodingEnabled: $practiceActivities__userSkeletonColorCodingEnabled,
+    showUserSkeleton: $practiceActivities__showUserSkeleton,
 }
 
 $: {
     if (persistInSettings) {
         $practiceActivities__playbackSpeed = practiceActivityParams.playbackSpeed;
         $practiceActivities__terminalFeedbackEnabled = practiceActivityParams.terminalFeedbackEnabled;
-        $practiceActivities__userSkeletonColorCodingEnabled = practiceActivityParams.userSkeletonColorCodingEnabled;
+        $practiceActivities__showUserSkeleton = practiceActivityParams.showUserSkeleton;
     }
 }
 </script>
@@ -35,8 +35,8 @@ $: {
         {/each}
     </div>
     <div class="control">
-        <label for="enableUserSkeletonColorCoding">Live Color Coding</label>
-        <input type="checkbox" name="enableUserSkeletonColorCoding" bind:checked={practiceActivityParams.userSkeletonColorCodingEnabled} />
+        <label for="enableUserSkeletonColorCoding">Show Skeleton</label>
+        <input type="checkbox" name="enableUserSkeletonColorCoding" bind:checked={practiceActivityParams.showUserSkeleton} />
     </div>
     <div class="control">
         <label for="terminalFeedbackEnabled">Provide Feedback</label>

--- a/svelte-web-frontend/src/lib/elements/TerminalFeedbackScreen.svelte
+++ b/svelte-web-frontend/src/lib/elements/TerminalFeedbackScreen.svelte
@@ -13,7 +13,6 @@ import { replaceJSONForStringifyDisplay } from '$lib/utils/formatting';
 import Dialog from './Dialog.svelte';
 import ProgressEllipses from './ProgressEllipses.svelte';
 import SpeechInterface from './SpeechInterface.svelte';
-
 import PerformanceReviewPage from '$lib/pages/PerformanceReviewPage.svelte';
 
 import InfoIcon from 'virtual:icons/mdi/information';
@@ -22,6 +21,7 @@ import StarIcon from 'virtual:icons/mdi/star';
 const dispatch = createEventDispatcher();
 
 export let feedback: TerminalFeedback | null = null;
+export let showActivityConfiguratorButton = false;
 
 let showingPerformanceReviewPage = false;
 
@@ -56,6 +56,14 @@ function generateActions(
         ...repeatAction,
         suggested: isSuggestingRepeat,
     });
+
+    if (showActivityConfiguratorButton) {
+        actions.push({
+            title: "Practice Settings ⚙️",
+            onClick: async () => { dispatch("configure-activity-clicked"); },
+            type: 'button',
+        })
+    }
 
     if (feedback?.videoRecording) {
         const videoRecording = feedback.videoRecording;

--- a/svelte-web-frontend/src/lib/model/PracticeActivity.ts
+++ b/svelte-web-frontend/src/lib/model/PracticeActivity.ts
@@ -65,8 +65,8 @@ export default interface PracticeActivity {
     endTime: number;
     interfaceMode: PracticeInterfaceModeKey;
     terminalFeedbackEnabled: boolean;
-    enableUserSkeletonColorCoding: boolean;
-    playbackSpeed: number | 'default';
+    userSkeletonColorCodingEnabled: boolean;
+    playbackSpeed: number;
     segmentDescription: string;
     dance?: Dance;
     danceTree?: DanceTree;

--- a/svelte-web-frontend/src/lib/model/PracticeActivity.ts
+++ b/svelte-web-frontend/src/lib/model/PracticeActivity.ts
@@ -1,9 +1,71 @@
 import type { Dance, DanceTree, DanceTreeNode } from "$lib/data/dances-store";
 
+
+export type PracticeActivityInterfaceSettings = {
+    referenceVideo: {
+        visibility: 'visible' | 'hidden',
+        skeleton: 'user' | 'reference' | 'none',
+    },
+    userVideo: {
+        visibility: 'visible' | 'hidden',
+        skeleton: 'user' | 'reference' | 'none',
+    },
+}
+// 1. When marking, users will want to see the reference video, and 
+//    possibly themselves. They might want to test their marking by seeing
+//    only the virtual mirror. We shouldn't provide any live or terminal feedback.
+//    They should be able to review a recording of their performance.
+//
+//    * User only needs a skeleton over their own video in order to get in frame?
+//
+// 2. When drilling, the user will have a variety of needs. They may want to:
+//      - See the reference video, with a skeleton of themselves overlaid
+//      - See their own video, with a skeleton of the reference overlaid
+//      - See both videos, with a skeleton of themselves overlaid
+
+export const PracticeInterfaceModes = {
+    watchDemo : {
+        referenceVideo: {
+            visibility: 'visible',
+            skeleton: 'none',
+        },
+        userVideo: {
+            visibility: 'hidden',
+            skeleton: 'none',
+        },
+    } as PracticeActivityInterfaceSettings,
+
+    userVideoOnly : {
+        referenceVideo: {
+            visibility: 'hidden',
+            skeleton: 'none',
+        },
+        userVideo: {
+            visibility: 'visible',
+            skeleton: 'user',
+        },
+    } as PracticeActivityInterfaceSettings,
+
+    bothVideos : {
+        referenceVideo: {
+            visibility: 'visible',
+            skeleton: 'none',
+        },
+        userVideo: {
+            visibility: 'visible',
+            skeleton: 'user',
+        },
+    } as PracticeActivityInterfaceSettings,
+} as const;
+
+export type PracticeInterfaceModeKey = keyof typeof PracticeInterfaceModes;
+export const PracticeActivityDefaultInterfaceSetting: PracticeInterfaceModeKey = 'bothVideos';
 export default interface PracticeActivity {
     startTime: number;
     endTime: number;
-    activityTypes: Array<'watch' | 'mark' | 'drill' | 'fullout'>;
+    interfaceMode: PracticeInterfaceModeKey;
+    terminalFeedbackEnabled: boolean;
+    enableUserSkeletonColorCoding: boolean;
     playbackSpeed: number | 'default';
     segmentDescription: string;
     dance?: Dance;

--- a/svelte-web-frontend/src/lib/model/PracticeActivity.ts
+++ b/svelte-web-frontend/src/lib/model/PracticeActivity.ts
@@ -31,7 +31,7 @@ export const PracticeInterfaceModes = {
         },
         userVideo: {
             visibility: 'hidden',
-            skeleton: 'none',
+        skeleton: 'none',
         },
     } as PracticeActivityInterfaceSettings,
 

--- a/svelte-web-frontend/src/lib/model/PracticeActivity.ts
+++ b/svelte-web-frontend/src/lib/model/PracticeActivity.ts
@@ -70,7 +70,7 @@ export default interface PracticeActivity {
     endTime: number;
     interfaceMode: PracticeInterfaceModeKey;
     terminalFeedbackEnabled: boolean;
-    userSkeletonColorCodingEnabled: boolean;
+    showUserSkeleton: boolean;
     playbackSpeed: number;
     segmentDescription: string;
     dance?: Dance;

--- a/svelte-web-frontend/src/lib/model/PracticeActivity.ts
+++ b/svelte-web-frontend/src/lib/model/PracticeActivity.ts
@@ -59,6 +59,11 @@ export const PracticeInterfaceModes = {
 } as const;
 
 export type PracticeInterfaceModeKey = keyof typeof PracticeInterfaceModes;
+export const PracticeInterfaceModeOptions: Record<PracticeInterfaceModeKey, string> = {
+    watchDemo: 'Demo Video',
+    userVideoOnly: 'Demo + Mirror',
+    bothVideos: 'Mirror',
+} as const;
 export const PracticeActivityDefaultInterfaceSetting: PracticeInterfaceModeKey = 'bothVideos';
 export default interface PracticeActivity {
     startTime: number;

--- a/svelte-web-frontend/src/lib/model/TerminalFeedback.ts
+++ b/svelte-web-frontend/src/lib/model/TerminalFeedback.ts
@@ -21,7 +21,7 @@ export type TerminalFeedback = {
     segmentName?: string;
     suggestedAction: TerminalFeedbackAction;
     navigateOptions?: { label: string, url: string, nodeId?: string}[];
-    
+
     score?: {
         achieved: number;
         maximumPossible: number;

--- a/svelte-web-frontend/src/lib/model/settings.ts
+++ b/svelte-web-frontend/src/lib/model/settings.ts
@@ -23,7 +23,7 @@ const DEFAULT_SETTINGS = {
    practiceActivities__playbackSpeed: 0.5,
    practiceActivities__interfaceMode: 'bothVideos' as PracticeInterfaceModeKey,
    practiceActivities__terminalFeedbackEnabled: true,
-   practiceActivities__userSkeletonColorCodingEnabled: true,
+   practiceActivities__showUserSkeleton: true,
 }
 
 export const pauseDurationMin = 0.1;
@@ -85,7 +85,7 @@ export const practiceActivities__interfaceMode = createOptionsSettingsStore("pra
 export const practiceActivities__enablePerformanceRecording = createBoolSettingsStore("practiceActivities__enablePerformanceRecording", DEFAULT_SETTINGS.practiceActivities__enablePerformanceRecording);
 
 export const practiceActivities__terminalFeedbackEnabled = createBoolSettingsStore("practiceActivities__terminalFeedbackEnabled", DEFAULT_SETTINGS.practiceActivities__terminalFeedbackEnabled);
-export const practiceActivities__userSkeletonColorCodingEnabled = createBoolSettingsStore("practiceActivities__userSkeletonColorCodingEnabled", DEFAULT_SETTINGS.practiceActivities__userSkeletonColorCodingEnabled);
+export const practiceActivities__showUserSkeleton = createBoolSettingsStore("practiceActivities__showUserSkeleton", DEFAULT_SETTINGS.practiceActivities__showUserSkeleton);
 
 // Reset all variables to their default values
 export function resetSettingsToDefault() {
@@ -110,5 +110,5 @@ export function resetSettingsToDefault() {
     practiceActivities__interfaceMode.set(DEFAULT_SETTINGS.practiceActivities__interfaceMode);
     practiceActivities__enablePerformanceRecording.set(DEFAULT_SETTINGS.practiceActivities__enablePerformanceRecording);
     practiceActivities__terminalFeedbackEnabled.set(DEFAULT_SETTINGS.practiceActivities__terminalFeedbackEnabled);
-    practiceActivities__userSkeletonColorCodingEnabled.set(DEFAULT_SETTINGS.practiceActivities__userSkeletonColorCodingEnabled);
+    practiceActivities__showUserSkeleton.set(DEFAULT_SETTINGS.practiceActivities__showUserSkeleton);
 }

--- a/svelte-web-frontend/src/lib/model/settings.ts
+++ b/svelte-web-frontend/src/lib/model/settings.ts
@@ -17,6 +17,7 @@ const DEFAULT_SETTINGS = {
    summaryFeedback_skeleton3d_mediumPerformanceThreshold: 0.8,
    summaryFeedback_skeleton3d_goodPerformanceThreshold: 0.9,
    evaluation_summarizeSubsections: 'allnodes' as const,
+   metric__3dskeletonsimilarity__badJointStdDeviationThreshold: 1.5,
    danceVideoVolume: 0.5,
 }
 
@@ -71,6 +72,7 @@ export const evaluation_summarizeSubsectionsOptions = {
 export const evaluation_summarizeSubsections = createOptionsSettingsStore(
     "evaluation_analyzeSubsections", DEFAULT_SETTINGS.evaluation_summarizeSubsections, evaluation_summarizeSubsectionsOptions
 );
+export const metric__3dskeletonsimilarity__badJointStdDeviationThreshold = createNumberSettingsStore("metric__3dskeletonsimilarity__badJointStdDeviationThreshold", DEFAULT_SETTINGS.metric__3dskeletonsimilarity__badJointStdDeviationThreshold);
 export const summaryFeedback_skeleton3d_mediumPerformanceThreshold = createNumberSettingsStore("summaryFeedback_skeleton3d_mediumPerformanceThreshold", DEFAULT_SETTINGS.summaryFeedback_skeleton3d_mediumPerformanceThreshold);
 export const summaryFeedback_skeleton3d_goodPerformanceThreshold = createNumberSettingsStore("summaryFeedback_skeleton3d_goodPerformanceThreshold", DEFAULT_SETTINGS.summaryFeedback_skeleton3d_goodPerformanceThreshold);
 export const danceVideoVolume = createNumberSettingsStore("danceVideoVolume", DEFAULT_SETTINGS.danceVideoVolume);    
@@ -93,5 +95,6 @@ export function resetSettingsToDefault() {
     summaryFeedback_skeleton3d_mediumPerformanceThreshold.set(DEFAULT_SETTINGS.summaryFeedback_skeleton3d_mediumPerformanceThreshold);
     summaryFeedback_skeleton3d_goodPerformanceThreshold.set(DEFAULT_SETTINGS.summaryFeedback_skeleton3d_goodPerformanceThreshold);
     evaluation_summarizeSubsections.set(DEFAULT_SETTINGS.evaluation_summarizeSubsections)
+    metric__3dskeletonsimilarity__badJointStdDeviationThreshold.set(DEFAULT_SETTINGS.metric__3dskeletonsimilarity__badJointStdDeviationThreshold);
     danceVideoVolume.set(DEFAULT_SETTINGS.danceVideoVolume)
 }

--- a/svelte-web-frontend/src/lib/model/settings.ts
+++ b/svelte-web-frontend/src/lib/model/settings.ts
@@ -1,4 +1,5 @@
 import { writable } from 'svelte/store';
+import { PracticeInterfaceModeOptions, type PracticeInterfaceModeKey } from './PracticeActivity';
 
 const DEFAULT_SETTINGS = {
    debugMode: false,
@@ -6,8 +7,7 @@ const DEFAULT_SETTINGS = {
    debugMode__viewDanceMenuAsList: false,
    debugMode__addPlaceholderAchievement: false,
    pauseInPracticePage : false,
-   practiceFallbackPlaybackSpeed: 0.5,
-   practicePage__enablePerformanceRecording: true,
+   practiceActivities__enablePerformanceRecording: true,
    debugPauseDurationSecs : 1.0,
    evaluation_GoodBadTrialThreshold : 4.0,
    livefeedback_qijia2d_YellowThreshold : 3.0,
@@ -19,6 +19,11 @@ const DEFAULT_SETTINGS = {
    evaluation_summarizeSubsections: 'allnodes' as const,
    metric__3dskeletonsimilarity__badJointStdDeviationThreshold: 1.5,
    danceVideoVolume: 0.5,
+
+   practiceActivities__playbackSpeed: 0.5,
+   practiceActivities__interfaceMode: 'bothVideos' as PracticeInterfaceModeKey,
+   practiceActivities__terminalFeedbackEnabled: true,
+   practiceActivities__userSkeletonColorCodingEnabled: true,
 }
 
 export const pauseDurationMin = 0.1;
@@ -56,8 +61,6 @@ export const debugMode__viewDanceMenuAsList = createBoolSettingsStore("debugMode
 export const debugMode__addPlaceholderAchievement = createBoolSettingsStore("debugMode__addPlaceholderAchievement", DEFAULT_SETTINGS.debugMode__addPlaceholderAchievement);
 export const pauseInPracticePage = createBoolSettingsStore("pauseInPracticePage", DEFAULT_SETTINGS.pauseInPracticePage);
 export const debugPauseDurationSecs = createNumberSettingsStore("debugPauseDurationSecs", DEFAULT_SETTINGS.debugPauseDurationSecs);
-export const practiceFallbackPlaybackSpeed = createNumberSettingsStore("practiceFallbackPlaybackSpeed", DEFAULT_SETTINGS.practiceFallbackPlaybackSpeed);
-export const practicePage__enablePerformanceRecording = createBoolSettingsStore("practicePage__enablePerformanceRecording", DEFAULT_SETTINGS.practicePage__enablePerformanceRecording);
 export const evaluation_GoodBadTrialThreshold = createNumberSettingsStore("evaluation_GoodBadTrialThreshold", DEFAULT_SETTINGS.evaluation_GoodBadTrialThreshold);
 export const feedback_YellowThreshold = createNumberSettingsStore("feedback_YellowThreshold", DEFAULT_SETTINGS.livefeedback_qijia2d_YellowThreshold);
 export const feedback_GreenThreshold = createNumberSettingsStore("feedback_GreenThreshold", DEFAULT_SETTINGS.livefeedback_qijia2d_GreenThreshold);
@@ -77,6 +80,13 @@ export const summaryFeedback_skeleton3d_mediumPerformanceThreshold = createNumbe
 export const summaryFeedback_skeleton3d_goodPerformanceThreshold = createNumberSettingsStore("summaryFeedback_skeleton3d_goodPerformanceThreshold", DEFAULT_SETTINGS.summaryFeedback_skeleton3d_goodPerformanceThreshold);
 export const danceVideoVolume = createNumberSettingsStore("danceVideoVolume", DEFAULT_SETTINGS.danceVideoVolume);    
 
+export const practiceActivities__playbackSpeed = createNumberSettingsStore("practiceActivities__playbackSpeed", DEFAULT_SETTINGS.practiceActivities__playbackSpeed);
+export const practiceActivities__interfaceMode = createOptionsSettingsStore("practiceActivities__interfaceMode", DEFAULT_SETTINGS.practiceActivities__interfaceMode, PracticeInterfaceModeOptions);
+export const practiceActivities__enablePerformanceRecording = createBoolSettingsStore("practiceActivities__enablePerformanceRecording", DEFAULT_SETTINGS.practiceActivities__enablePerformanceRecording);
+
+export const practiceActivities__terminalFeedbackEnabled = createBoolSettingsStore("practiceActivities__terminalFeedbackEnabled", DEFAULT_SETTINGS.practiceActivities__terminalFeedbackEnabled);
+export const practiceActivities__userSkeletonColorCodingEnabled = createBoolSettingsStore("practiceActivities__userSkeletonColorCodingEnabled", DEFAULT_SETTINGS.practiceActivities__userSkeletonColorCodingEnabled);
+
 // Reset all variables to their default values
 export function resetSettingsToDefault() {
     debugMode.set(DEFAULT_SETTINGS.debugMode);
@@ -85,8 +95,6 @@ export function resetSettingsToDefault() {
     debugMode__addPlaceholderAchievement.set(DEFAULT_SETTINGS.debugMode__addPlaceholderAchievement);
     pauseInPracticePage.set(DEFAULT_SETTINGS.pauseInPracticePage);
     debugPauseDurationSecs.set(DEFAULT_SETTINGS.debugPauseDurationSecs);
-    practiceFallbackPlaybackSpeed.set(DEFAULT_SETTINGS.practiceFallbackPlaybackSpeed);
-    practicePage__enablePerformanceRecording.set(DEFAULT_SETTINGS.practicePage__enablePerformanceRecording);
     evaluation_GoodBadTrialThreshold.set(DEFAULT_SETTINGS.evaluation_GoodBadTrialThreshold);
     feedback_YellowThreshold.set(DEFAULT_SETTINGS.livefeedback_qijia2d_YellowThreshold);
     feedback_GreenThreshold.set(DEFAULT_SETTINGS.livefeedback_qijia2d_GreenThreshold);
@@ -97,4 +105,10 @@ export function resetSettingsToDefault() {
     evaluation_summarizeSubsections.set(DEFAULT_SETTINGS.evaluation_summarizeSubsections)
     metric__3dskeletonsimilarity__badJointStdDeviationThreshold.set(DEFAULT_SETTINGS.metric__3dskeletonsimilarity__badJointStdDeviationThreshold);
     danceVideoVolume.set(DEFAULT_SETTINGS.danceVideoVolume)
+
+    practiceActivities__playbackSpeed.set(DEFAULT_SETTINGS.practiceActivities__playbackSpeed);
+    practiceActivities__interfaceMode.set(DEFAULT_SETTINGS.practiceActivities__interfaceMode);
+    practiceActivities__enablePerformanceRecording.set(DEFAULT_SETTINGS.practiceActivities__enablePerformanceRecording);
+    practiceActivities__terminalFeedbackEnabled.set(DEFAULT_SETTINGS.practiceActivities__terminalFeedbackEnabled);
+    practiceActivities__userSkeletonColorCodingEnabled.set(DEFAULT_SETTINGS.practiceActivities__userSkeletonColorCodingEnabled);
 }

--- a/svelte-web-frontend/src/lib/pages/DanceTreePage.svelte
+++ b/svelte-web-frontend/src/lib/pages/DanceTreePage.svelte
@@ -56,7 +56,7 @@ let practiceActivityParams: GeneratePracticeActivityOptions = {
     playbackSpeed: $practiceActivities__playbackSpeed,
     interfaceMode: PracticeActivityDefaultInterfaceSetting,
     terminalFeedbackEnabled: true,
-    userSkeletonColorCodingEnabled: true,
+    showUserSkeleton: true,
 }
 $: {
     $practiceActivities__playbackSpeed = practiceActivityParams.playbackSpeed;

--- a/svelte-web-frontend/src/lib/pages/DanceTreePage.svelte
+++ b/svelte-web-frontend/src/lib/pages/DanceTreePage.svelte
@@ -4,10 +4,10 @@ import { page, navigating } from '$app/stores'
 import { navbarProps } from '$lib/elements/NavBar.svelte';
 
 import SketchButton from '$lib/elements/SketchButton.svelte';
-import { getDanceVideoSrc, type Dance, type DanceTree, type DanceTreeNode } from '$lib/data/dances-store';
+import { getDanceVideoSrc, type Dance, type DanceTree, type DanceTreeNode, findDanceTreeNode } from '$lib/data/dances-store';
 import type { NodeHighlight } from '$lib/elements/DanceTreeVisual.svelte';
 import DanceTreeVisual from '$lib/elements/DanceTreeVisual.svelte';
-import { tick } from 'svelte';
+import { createEventDispatcher, onMount, tick } from 'svelte';
 
 import VideoWithSkeleton from '$lib/elements/VideoWithSkeleton.svelte';
 import { danceVideoVolume, debugMode, debugMode__viewBeatsOnDanceTreepage } from '$lib/model/settings';
@@ -15,10 +15,16 @@ import ProgressEllipses from '$lib/elements/ProgressEllipses.svelte';
 import { GeneratePracticeActivity } from '$lib/ai/TeachingAgent';
 import { PracticeActivityDefaultInterfaceSetting, PracticeInterfaceModes, type PracticeInterfaceModeKey } from '$lib/model/PracticeActivity';
 
+import InfoIcon from 'virtual:icons/icon-park-outline/info';
+
 export let dance: Dance;
 export let danceTree: DanceTree;
+export let preselectedNodeId: string | null = null;
+
+const dispatch = createEventDispatcher();
 
 // Pin the video small, so the flexbox system can auto-size the height
+let videoElement: VideoWithSkeleton | undefined;
 let fitVideoToFlexbox = true;
 
 let danceSrc: string = '';
@@ -31,7 +37,8 @@ $: danceBeatTimes = dance?.all_beat_times ?? [];
 let videoPaused: boolean = true;
 let stopTime: number = Infinity;
 let videoCurrentTime: number = 0;
-let currentPlayingNode: DanceTreeNode | null = null;
+let currentPlayingNode: DanceTreeNode | null = preselectedNodeId === null ? null : findDanceTreeNode(danceTree, preselectedNodeId);
+$: dispatch('selected-node', currentPlayingNode?.id);
 
 let videoPlaybackSpeed: number = 1;
 let videoDuration: number;
@@ -69,18 +76,22 @@ $: {
     }));
 }
 
+async function playSelectedNode() {
+    if (!currentPlayingNode || !videoElement) return;
+
+    videoCurrentTime = currentPlayingNode.start_time;
+    stopTime = currentPlayingNode.end_time;
+    await tick();
+    await videoElement.play();
+}
+
 async function onNodeClicked(e: any) {
     console.log('node clicked', e.detail);
 
     const selectedTreeNode = e.detail as DanceTreeNode;
     videoPaused = true;
-    stopTime = selectedTreeNode.end_time;
     currentPlayingNode = selectedTreeNode;
-    await tick();
-    videoCurrentTime = selectedTreeNode.start_time;
-    await tick();
-    videoPaused = false;
-    // videoElement.play();
+    await playSelectedNode();
 }
 
 function showProgress(node: DanceTreeNode) {
@@ -119,9 +130,38 @@ $: {
         };
     }
     else {
-        nodeHighlights = {};
+
+        // Find the node corresponding to the first segment (but choose one that isn't too short)
+        let node = danceTree.root as DanceTreeNode;
+        const minFirstSegmentLength = 4;
+        while (node.children.length > 0 && (node.end_time - node.start_time > minFirstSegmentLength)) {
+            node = node.children[0] as DanceTreeNode;
+        }
+
+        nodeHighlights = {
+            [node.id]: {
+                color: 'yellow',
+                label: 'Click a node',
+                pulse: true,
+            }
+        };
     }
 }
+
+onMount(() => {
+
+    if (videoElement && currentPlayingNode) {  
+        
+        // Option 1: Just have it set to the end of the preselected
+        videoCurrentTime = currentPlayingNode.end_time   
+
+        // Option 2: Play the node that was preselected
+        // const nodeId = currentPlayingNode.id;
+        // playSelectedNode().catch((e) => {
+        //     console.warn(`DanceTreePage: unable to autoplay preselected node ${nodeId}`, e);
+        // });
+    }
+});
 
 </script>
 
@@ -145,7 +185,9 @@ $: {
     <div class="preview-container cols">
         <div class="col ml-4 pb-4 vfill flex flex-col flex-crossaxis-center flex-mainaxis-stretch">
         
-            <VideoWithSkeleton bind:currentTime={videoCurrentTime}
+            <VideoWithSkeleton 
+                bind:this={videoElement}
+                bind:currentTime={videoCurrentTime}
                 bind:playbackRate={videoPlaybackSpeed}
                 bind:duration={videoDuration}
                 bind:paused={videoPaused}
@@ -157,8 +199,8 @@ $: {
             </VideoWithSkeleton>
         </div>
         <div class="col vfill flex flex-col flex-center controls">
-                {#if currentPlayingNode}
-                <h3>Playing '{currentPlayingNode.id}'</h3>
+            <h3>Pratice Configuration</h3>
+            {#if currentPlayingNode}
                 <div class="control">
                     <label for="playbackSpeed">Speed:</label>
                     <input type="range" name="playbackSpeed" bind:value={videoPlaybackSpeed} min="0.4" max="1.3" step="0.1" />
@@ -182,7 +224,7 @@ $: {
                     </SketchButton>
                 </div>
             {:else}
-                <h3>Click above to select a part of the song to practice</h3>
+                <p class="text-label" style="max-width: 25ch"><span><InfoIcon /></span> Click above to select a part of the song to practice</p>
             {/if}
         </div>
     </div>

--- a/svelte-web-frontend/src/lib/pages/DanceTreePage.svelte
+++ b/svelte-web-frontend/src/lib/pages/DanceTreePage.svelte
@@ -16,6 +16,11 @@ import { GeneratePracticeActivity } from '$lib/ai/TeachingAgent';
 import { PracticeActivityDefaultInterfaceSetting, PracticeInterfaceModes, type PracticeInterfaceModeKey } from '$lib/model/PracticeActivity';
 
 import InfoIcon from 'virtual:icons/icon-park-outline/info';
+import NameIcon from 'virtual:icons/icon-park-outline/info';
+import ClockIcon from 'virtual:icons/icon-park-outline/alarm-clock';
+import DanceIcon from 'virtual:icons/mdi/human-female-dance';
+
+import frontendPerformanceHistory from '$lib/ai/frontendPerformanceHistory';
 
 export let dance: Dance;
 export let danceTree: DanceTree;
@@ -39,6 +44,10 @@ let stopTime: number = Infinity;
 let videoCurrentTime: number = 0;
 let currentPlayingNode: DanceTreeNode | null = preselectedNodeId === null ? null : findDanceTreeNode(danceTree, preselectedNodeId);
 $: dispatch('selected-node', currentPlayingNode?.id);
+
+let lastNAttemptsOfDance = frontendPerformanceHistory.lastNAttemptsAllSegments(dance.clipRelativeStem, 'basicInfo');
+let currentSegmentAttemptCount: number;
+$: currentSegmentAttemptCount = currentPlayingNode ? $lastNAttemptsOfDance.filter(x => x.segmentId === currentPlayingNode?.id).length : 0;
 
 let videoPlaybackSpeed: number = 1;
 let videoDuration: number;
@@ -126,6 +135,8 @@ $: {
             [currentPlayingNode.id]: {
                 color: 'var(--color-theme-1)',
                 label: currentPlayingNode.id,
+                pulse: false,
+                borderColor: 'black'
             }
         };
     }
@@ -183,7 +194,7 @@ onMount(() => {
     </div>
      
     <div class="preview-container cols">
-        <div class="col ml-4 pb-4 vfill flex flex-col flex-crossaxis-center flex-mainaxis-stretch">
+        <div class="col ml-4 pb-4 vfill flex flex-col flex-crossaxis-end flex-mainaxis-stretch">
         
             <VideoWithSkeleton 
                 bind:this={videoElement}
@@ -198,7 +209,15 @@ onMount(() => {
                 <source src={danceSrc} type="video/mp4" />
             </VideoWithSkeleton>
         </div>
-        <div class="col vfill flex flex-col flex-center controls">
+        <div class="col flex flex-col flex-center controls">
+            {#if currentPlayingNode}
+            <h3>Information</h3>
+            <div class="infoList">
+                <span class="label" title="Section Name"><NameIcon /></span><span class="data">{currentPlayingNode.id}</span>
+                <span class="label" title="Duration"><ClockIcon /></span><span class="data">{(currentPlayingNode.end_time - currentPlayingNode.start_time).toFixed(2)}s</span>
+                <span class="label" title="Attempts"><DanceIcon /></span><span class="data">{currentSegmentAttemptCount}</span>
+            </div>
+            {/if}
             <h3>Pratice Configuration</h3>
             {#if currentPlayingNode}
                 <div class="control">
@@ -240,6 +259,8 @@ section {
     display: grid;
     grid-template-rows: auto minmax(0, 1fr); 
     gap: 1rem;
+
+    --height-transition-duration: 0.25s;
 }
 
 .preview-container {
@@ -262,6 +283,34 @@ section {
 
 .controls {
     gap: 0.5rem;
+    // flex-basis: auto;
+    // flex-grow: 0;
+    margin-right: 1rem;
+}
+h3 {
+    margin-bottom: 0.25rem;;
+}
+.infoList {
+    display: grid;
+    grid-template-columns: auto auto;
+    gap: 0.25rem;
+    margin: 0rem 0 1rem 0;
+
+    & .label {
+        color: var(--color-text-label);
+        font-weight: 500;
+        justify-self: end;
+        align-self: center;
+        margin-right: 0.25rem;
+    }
+
+    & .data {
+        // font-family: monospace;
+        // font-size: 0.9em;
+        justify-self: start;
+        align-self: center;
+        // color: var(--color-text-label);
+    }
 }
 
 .control {

--- a/svelte-web-frontend/src/lib/pages/DanceTreePage.svelte
+++ b/svelte-web-frontend/src/lib/pages/DanceTreePage.svelte
@@ -10,9 +10,9 @@ import DanceTreeVisual from '$lib/elements/DanceTreeVisual.svelte';
 import { createEventDispatcher, onMount, tick } from 'svelte';
 
 import VideoWithSkeleton from '$lib/elements/VideoWithSkeleton.svelte';
-import { danceVideoVolume, debugMode, debugMode__viewBeatsOnDanceTreepage, practiceFallbackPlaybackSpeed } from '$lib/model/settings';
+import { danceVideoVolume, debugMode, debugMode__viewBeatsOnDanceTreepage, practiceActivities__playbackSpeed } from '$lib/model/settings';
 import ProgressEllipses from '$lib/elements/ProgressEllipses.svelte';
-import { GeneratePracticeActivity, type GeneratePracticeActivityParams } from '$lib/ai/TeachingAgent';
+import { GeneratePracticeActivity, type GeneratePracticeActivityOptions } from '$lib/ai/TeachingAgent';
 import { PracticeActivityDefaultInterfaceSetting, PracticeInterfaceModes, type PracticeInterfaceModeKey } from '$lib/model/PracticeActivity';
 
 import InfoIcon from 'virtual:icons/icon-park-outline/info';
@@ -51,22 +51,19 @@ $: currentSegmentAttemptCount = currentPlayingNode ? $lastNAttemptsOfDance.filte
 
 let videoDuration: number;
 
-let practiceActivityParams: GeneratePracticeActivityParams = {
-    dance: dance,
-    danceTree: danceTree,
-    danceTreeNode: currentPlayingNode as DanceTreeNode,
-    playbackSpeed: $practiceFallbackPlaybackSpeed,
+let practiceActivityParams: GeneratePracticeActivityOptions = {
+    playbackSpeed: $practiceActivities__playbackSpeed,
     interfaceMode: PracticeActivityDefaultInterfaceSetting,
     terminalFeedbackEnabled: true,
     userSkeletonColorCodingEnabled: true,
 }
 $: {
-    $practiceFallbackPlaybackSpeed = practiceActivityParams.playbackSpeed;
+    $practiceActivities__playbackSpeed = practiceActivityParams.playbackSpeed;
 }
 
 const interfaceModeOptions: {
     title: string,
-    value: PracticeInterfaceModeKey,
+value: PracticeInterfaceModeKey,
     iconUrl?: string,
 }[] = [
     {
@@ -122,7 +119,12 @@ async function practiceClicked() {
     try {
         if (!currentPlayingNode) throw new Error('No node selected');
         
-        const { activity, url} = GeneratePracticeActivity(practiceActivityParams);
+        const { activity, url} = GeneratePracticeActivity(
+            dance,
+            danceTree,
+            currentPlayingNode as DanceTreeNode,
+            practiceActivityParams
+        );
         
         await goto(url);
     } 

--- a/svelte-web-frontend/src/lib/pages/DanceTreePage.svelte
+++ b/svelte-web-frontend/src/lib/pages/DanceTreePage.svelte
@@ -12,6 +12,8 @@ import { tick } from 'svelte';
 import VideoWithSkeleton from '$lib/elements/VideoWithSkeleton.svelte';
 import { danceVideoVolume, debugMode, debugMode__viewBeatsOnDanceTreepage } from '$lib/model/settings';
 import ProgressEllipses from '$lib/elements/ProgressEllipses.svelte';
+import { GeneratePracticeActivity } from '$lib/ai/TeachingAgent';
+import { PracticeActivityDefaultInterfaceSetting, PracticeInterfaceModes, type PracticeInterfaceModeKey } from '$lib/model/PracticeActivity';
 
 export let dance: Dance;
 export let danceTree: DanceTree;
@@ -29,10 +31,30 @@ $: danceBeatTimes = dance?.all_beat_times ?? [];
 let videoPaused: boolean = true;
 let stopTime: number = Infinity;
 let videoCurrentTime: number = 0;
-let videoPlaybackSpeed: number = 1;
 let currentPlayingNode: DanceTreeNode | null = null;
 
+let videoPlaybackSpeed: number = 1;
 let videoDuration: number;
+
+let practiceActivityInterfaceMode: PracticeInterfaceModeKey = PracticeActivityDefaultInterfaceSetting;
+const interfaceModeOptions: {
+    title: string,
+    value: PracticeInterfaceModeKey,
+    iconUrl?: string,
+}[] = [
+    {
+        title: 'Demo Video',
+        value: 'watchDemo'
+    },
+    {
+        title: 'Demo + Mirror',
+        value: 'bothVideos',
+    },
+    {
+        title: 'Mirror',
+        value: 'userVideoOnly',
+    },
+]
 
 $: if (videoCurrentTime > stopTime) {
     videoPaused = true;
@@ -68,10 +90,17 @@ function showProgress(node: DanceTreeNode) {
 async function practiceClicked() {
     try {
         if (!currentPlayingNode) throw new Error('No node selected');
-
-        // @ts-ignore
-        const curPath: string = $page?.path ?? "";
-        const url = `${curPath}practicenode/${currentPlayingNode.id}?playbackSpeed=${videoPlaybackSpeed}`;
+        
+        const { activity, url} = GeneratePracticeActivity({
+            dance: dance,
+            danceTree: danceTree,
+            danceTreeNode: currentPlayingNode,
+            playbackSpeed: videoPlaybackSpeed,
+            interfaceMode: practiceActivityInterfaceMode,
+            terminalFeedbackEnabled: true,
+            enableUserSkeletonColorCoding: true,
+        });
+        
         await goto(url);
     } 
     catch(e) {
@@ -128,29 +157,32 @@ $: {
             </VideoWithSkeleton>
         </div>
         <div class="col vfill flex flex-col flex-center controls">
-            <h3>
                 {#if currentPlayingNode}
-                    Playing '{currentPlayingNode.id}'
-                {:else}
-                    Select a part of the song to practice
-                {/if}
-            </h3>
-            <div class="control">
-                <label for="playbackSpeed">Speed:</label>
-                <input type="range" name="playbackSpeed" bind:value={videoPlaybackSpeed} min="0.4" max="1.2" step="0.1" />
-                {videoPlaybackSpeed.toFixed(1)}x
-            </div>
-            {#if currentPlayingNode}
-                {#if $debugMode}
-                <span>{currentPlayingNode.id}</span>
-                {/if}
-                <SketchButton on:click={practiceClicked} disabled={$navigating !== null}>
-                    {#if $navigating}
-                        Navigating<ProgressEllipses />
-                    {:else}
-                        Practice {currentPlayingNode.id}
-                    {/if}
-                </SketchButton>
+                <h3>Playing '{currentPlayingNode.id}'</h3>
+                <div class="control">
+                    <label for="playbackSpeed">Speed:</label>
+                    <input type="range" name="playbackSpeed" bind:value={videoPlaybackSpeed} min="0.4" max="1.3" step="0.1" />
+                    {videoPlaybackSpeed.toFixed(1)}x
+                </div>
+                <div class="control interfaceMode" >
+                    {#each interfaceModeOptions as interfaceModeOption}
+                    <label class="button outlined thin" class:selected={interfaceModeOption.value === practiceActivityInterfaceMode }>
+                        {interfaceModeOption.title}
+                        <input type="radio" name="practiceActivityInterfaceMode" value={interfaceModeOption.value} bind:group={practiceActivityInterfaceMode}/>
+                    </label>
+                    {/each}
+                </div>
+                <div class="control mt-4">
+                    <SketchButton on:click={practiceClicked} disabled={$navigating !== null}>
+                        {#if $navigating}
+                            Navigating<ProgressEllipses />
+                        {:else}
+                            Practice {currentPlayingNode.id} ➡️
+                        {/if}
+                    </SketchButton>
+                </div>
+            {:else}
+                <h3>Click above to select a part of the song to practice</h3>
             {/if}
         </div>
     </div>
@@ -200,5 +232,40 @@ section {
     input[type="range"] {
         max-width: 10ch;
     }
+
+    &.interfaceMode label {
+        box-sizing: border-box;
+        padding: 0.25em;
+        width: 5em;
+        height: 5em;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        text-align: center;
+        // border-radius: var(--std-border-radius);
+        box-shadow: 2px 2px 2px 2px rgba(0, 0, 0, 0.3);
+
+        & input {
+            position:absolute;
+            left: -50%;
+            opacity: 0;
+            width: 0;
+            height: 0;
+
+        }
+
+        &:has( > input:checked) {
+            color: red;
+        }
+
+        &.selected {
+            color: var(--color-theme-1);
+            border-color: var(--color-theme-1);
+            border-width: 3px;
+            background: white;
+        }
+    }
+
+    // &.interfaceMode label:has(input[selected=true])
 }
 </style>

--- a/svelte-web-frontend/src/lib/pages/DanceTreePage.svelte
+++ b/svelte-web-frontend/src/lib/pages/DanceTreePage.svelte
@@ -4,6 +4,7 @@ import { page, navigating } from '$app/stores'
 import { navbarProps } from '$lib/elements/NavBar.svelte';
 
 import SketchButton from '$lib/elements/SketchButton.svelte';
+import PracticeActivityConfigurator from '$lib/elements/PracticeActivityConfigurator.svelte';
 import { getDanceVideoSrc, type Dance, type DanceTree, type DanceTreeNode, findDanceTreeNode } from '$lib/data/dances-store';
 import type { NodeHighlight } from '$lib/elements/DanceTreeVisual.svelte';
 import DanceTreeVisual from '$lib/elements/DanceTreeVisual.svelte';
@@ -225,27 +226,10 @@ onMount(() => {
             {/if}
             <h3>Pratice Configuration</h3>
             {#if currentPlayingNode}
-                <div class="control">
-                    <label for="playbackSpeed">Speed:</label>
-                    <input type="range" name="playbackSpeed" bind:value={practiceActivityParams.playbackSpeed} min="0.4" max="1.3" step="0.1" />
-                    {practiceActivityParams.playbackSpeed.toFixed(1)}x
-                </div>
-                <div class="control interfaceMode" >
-                    {#each interfaceModeOptions as interfaceModeOption}
-                    <label class="button outlined thin" class:selected={interfaceModeOption.value === practiceActivityParams.interfaceMode }>
-                        {interfaceModeOption.title}
-                        <input type="radio" name="practiceActivityInterfaceMode" value={interfaceModeOption.value} bind:group={practiceActivityParams.interfaceMode}/>
-                    </label>
-                    {/each}
-                </div>
-                <div class="control">
-                    <label for="enableUserSkeletonColorCoding">Live Color Coding</label>
-                    <input type="checkbox" name="enableUserSkeletonColorCoding" bind:checked={practiceActivityParams.userSkeletonColorCodingEnabled} />
-                </div>
-                <div class="control">
-                    <label for="terminalFeedbackEnabled">Provide Feedback</label>
-                    <input type="checkbox" name="terminalFeedbackEnabled" bind:checked={practiceActivityParams.terminalFeedbackEnabled} />
-                </div>
+                <PracticeActivityConfigurator 
+                    persistInSettings={true}
+                    bind:practiceActivityParams={practiceActivityParams}
+                />
                 <div class="control mt-4">
                     <SketchButton on:click={practiceClicked} disabled={$navigating !== null}>
                         {#if $navigating}
@@ -326,50 +310,4 @@ h3 {
     }
 }
 
-.control {
-    display: flex;
-    flex-direction: row; 
-    align-items: center;
-    justify-content: center;
-    gap: 1ch;
-
-    input[type="range"] {
-        max-width: 10ch;
-    }
-
-    &.interfaceMode label {
-        box-sizing: border-box;
-        padding: 0.25em;
-        width: 5em;
-        height: 5em;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        text-align: center;
-        // border-radius: var(--std-border-radius);
-        box-shadow: 2px 2px 2px 2px rgba(0, 0, 0, 0.3);
-
-        & input {
-            position:absolute;
-            left: -50%;
-            opacity: 0;
-            width: 0;
-            height: 0;
-
-        }
-
-        &:has( > input:checked) {
-            color: red;
-        }
-
-        &.selected {
-            color: var(--color-theme-1);
-            border-color: var(--color-theme-1);
-            border-width: 3px;
-            background: white;
-        }
-    }
-
-    // &.interfaceMode label:has(input[selected=true])
-}
 </style>

--- a/svelte-web-frontend/src/lib/pages/PracticePage.svelte
+++ b/svelte-web-frontend/src/lib/pages/PracticePage.svelte
@@ -463,7 +463,7 @@ async function startCountdown() {
             webcamRecordedChunks.push(e.data);
         });
         webcamRecorder.addEventListener('stop', () => {
-            let recordedVideoURL = URL.createObjectURL(new Blob(webcamRecordedChunks));
+            let recordedVideoURL = URL.createObjectURL(new Blob(webcamRecordedChunks, {type: webcamRecorderMimeType}));
             resolveWebcamRecordedObjectUrl?.(recordedVideoURL);
         });
         webcamRecorder.start();

--- a/svelte-web-frontend/src/lib/pages/PracticePage.svelte
+++ b/svelte-web-frontend/src/lib/pages/PracticePage.svelte
@@ -3,7 +3,7 @@ export type PracticePageState = "waitWebcam" | "waitStart" | 'waitStartUserInter
 export const INITIAL_STATE: PracticePageState = "waitWebcam";
 </script>
 <script lang="ts">
-import { danceVideoVolume, debugMode__addPlaceholderAchievement, practicePage__enablePerformanceRecording } from './../model/settings';
+import { danceVideoVolume, debugMode__addPlaceholderAchievement, metric__3dskeletonsimilarity__badJointStdDeviationThreshold, practicePage__enablePerformanceRecording } from './../model/settings';
 import { v4 as generateUUIDv4 } from 'uuid';
 import { evaluation_summarizeSubsections, practiceFallbackPlaybackSpeed, summaryFeedback_skeleton3d_mediumPerformanceThreshold, summaryFeedback_skeleton3d_goodPerformanceThreshold } from '$lib/model/settings';
 // import { replaceJSONForStringifyDisplay } from '$lib/utils/formatting';
@@ -248,6 +248,7 @@ async function getFeedback(performanceSummary: FrontendPerformanceSummary | null
                 dancePerfHistory ?? undefined,
                 $summaryFeedback_skeleton3d_mediumPerformanceThreshold,
                 $summaryFeedback_skeleton3d_goodPerformanceThreshold,
+                $metric__3dskeletonsimilarity__badJointStdDeviationThreshold,
                 attemptHistory,
             )
         } catch(e) {

--- a/svelte-web-frontend/src/lib/pages/PracticePage.svelte
+++ b/svelte-web-frontend/src/lib/pages/PracticePage.svelte
@@ -724,7 +724,6 @@ onMount(() => {
 <section class="practicePage" 
     class:hasDanceTree={practiceActivity?.danceTree}
     class:hasFeedback={isShowingFeedback}
-    class:hasActivityConfigurator={isShowingFeedback && isShowingNextActivityConfigurator}
     class:isPracticing={!isShowingFeedback}
     class:hasOnlyDemoVideo={hasVisibleReferenceVideo && !hasUserWebcamVisible}
     class:hasOnlyUserMirror={hasUserWebcamVisible && !hasVisibleReferenceVideo}
@@ -809,16 +808,14 @@ onMount(() => {
         />
         <!-- <pre>{JSON.stringify(performanceSummary, replaceJSONForStringifyDisplay, 2)}</pre> -->
     </div>
-        {#if isShowingNextActivityConfigurator}
-        <div class="activityConfigurator">
-            <CloseButton isVisible={isShowingNextActivityConfigurator} on:click={() => isShowingNextActivityConfigurator = false } />
-            <h3>Pratice Configuration</h3>
-            <PracticeActivityConfigurator 
+    <Dialog open={isShowingNextActivityConfigurator}
+        on:dialog-closed={() => isShowingNextActivityConfigurator = false}>
+        <span slot="title">Pratice Configuration</span>
+        <PracticeActivityConfigurator 
                 persistInSettings={true}
                 bind:practiceActivityParams={nextPracticeActivityParams}
             />
-        </div>
-        {/if}
+    </Dialog>
     {/if}
 
     {#if countdown >= 0}
@@ -881,20 +878,11 @@ section {
     }
     &.hasFeedback {
         grid-template: "feedback feedback" 1fr / 1fr 1fr;
-        &.hasActivityConfigurator {
-            grid-template: "feedback activityConfigurator" 1fr / auto 1fr;
-        }
     }
     &.hasDanceTree.hasFeedback {
         grid-template:
             "treevis treevis" auto
             "feedback feedback" 1fr / 1fr 1fr;
-
-        &.hasActivityConfigurator {
-            grid-template:
-                "treevis treevis" auto
-                "feedback activityConfigurator" 1fr / 1fr auto;
-        }
     }
     
     align-items: center;

--- a/svelte-web-frontend/src/lib/pages/PracticePage.svelte
+++ b/svelte-web-frontend/src/lib/pages/PracticePage.svelte
@@ -3,7 +3,7 @@ export type PracticePageState = "waitWebcam" | "waitStart" | 'waitStartUserInter
 export const INITIAL_STATE: PracticePageState = "waitWebcam";
 </script>
 <script lang="ts">
-import { danceVideoVolume, debugMode__addPlaceholderAchievement, metric__3dskeletonsimilarity__badJointStdDeviationThreshold, practiceActivities__enablePerformanceRecording, practiceActivities__interfaceMode, practiceActivities__terminalFeedbackEnabled, practiceActivities__userSkeletonColorCodingEnabled } from './../model/settings';
+import { danceVideoVolume, debugMode__addPlaceholderAchievement, metric__3dskeletonsimilarity__badJointStdDeviationThreshold, practiceActivities__enablePerformanceRecording, practiceActivities__interfaceMode, practiceActivities__terminalFeedbackEnabled, practiceActivities__showUserSkeleton } from './../model/settings';
 import { v4 as generateUUIDv4 } from 'uuid';
 import { evaluation_summarizeSubsections, practiceActivities__playbackSpeed, summaryFeedback_skeleton3d_mediumPerformanceThreshold, summaryFeedback_skeleton3d_goodPerformanceThreshold } from '$lib/model/settings';
 // import { replaceJSONForStringifyDisplay } from '$lib/utils/formatting';
@@ -163,7 +163,7 @@ let nextPracticeActivityParams: GeneratePracticeActivityOptions = {
     playbackSpeed: practiceActivity?.playbackSpeed ?? $practiceActivities__playbackSpeed,
     interfaceMode: practiceActivity?.interfaceMode ?? $practiceActivities__interfaceMode,
     terminalFeedbackEnabled: practiceActivity?.terminalFeedbackEnabled ?? $practiceActivities__terminalFeedbackEnabled,
-    userSkeletonColorCodingEnabled: practiceActivity?.userSkeletonColorCodingEnabled ?? $practiceActivities__userSkeletonColorCodingEnabled,
+    showUserSkeleton: practiceActivity?.showUserSkeleton ?? $practiceActivities__showUserSkeleton,
 }
 
 async function onNodeClicked(clickedNode: DanceTreeNode) {
@@ -208,8 +208,8 @@ $: {
         || (interfaceSettings.referenceVideo.visibility === 'visible' && interfaceSettings.referenceVideo.skeleton === 'user')
         || (interfaceSettings.userVideo.visibility === 'visible' && interfaceSettings.userVideo.skeleton === 'user');
 }
-let colorCodingEnabled: boolean;
-$: colorCodingEnabled = practiceActivity?.userSkeletonColorCodingEnabled ?? true;
+let skeletonDrawingEnabled: boolean;
+$: skeletonDrawingEnabled = practiceActivity?.showUserSkeleton ?? true;
 let terminalFeedbackEnabled: boolean;
 $: terminalFeedbackEnabled = practiceActivity?.terminalFeedbackEnabled ?? true;
 
@@ -781,7 +781,9 @@ onMount(() => {
             drawSkeleton={false}
             poseEstimationCheckFunction={shouldSendNextPoseEstimationFrame}
             customDrawFn={(ctx, pose) => {
-                const evalResToPass = colorCodingEnabled ? lastEvaluationResult : null;
+                if (!skeletonDrawingEnabled) return;
+                
+                const evalResToPass = skeletonDrawingEnabled ? lastEvaluationResult : null;
                 Draw2dSkeleton(ctx, pose, evalResToPass, mirrorForEvaluation);
             }}
             on:poseEstimationFrameSent={poseEstimationFrameSent}

--- a/svelte-web-frontend/src/lib/pages/SettingsPage.svelte
+++ b/svelte-web-frontend/src/lib/pages/SettingsPage.svelte
@@ -20,8 +20,7 @@ import {
     evaluation_summarizeSubsectionsOptions,
     metric__3dskeletonsimilarity__badJointStdDeviationThreshold,
 	useTextToSpeech,
-	practiceFallbackPlaybackSpeed,
-    practicePage__enablePerformanceRecording,
+    practiceActivities__enablePerformanceRecording,
 	summaryFeedback_skeleton3d_mediumPerformanceThreshold,
     summaryFeedback_skeleton3d_goodPerformanceThreshold,
 	danceVideoVolume,
@@ -83,10 +82,6 @@ function clearPerformanceHistory() {
         <h3>Practice Page</h3>
         {#if $debugMode}
         <div>
-            <label for="practiceFallbackPlaybackSpeed">Fallback Speed</label>
-            <input class="outlined thin" type="number" name="practiceFallbackPlaybackSpeed" bind:value={$practiceFallbackPlaybackSpeed} min={0.1} max={1.5} step={0.05}>
-        </div>
-        <div>
             <label for="pauseInPracticePage">Add midway Pause</label>
             <input type="checkbox" name="pauseInPracticePage" bind:checked={$pauseInPracticePage}>
         </div>
@@ -96,8 +91,8 @@ function clearPerformanceHistory() {
         </div>
         {/if}
         <div>
-            <label for="practicePage__enablePerformanceRecording">Record Performances</label>
-            <input type="checkbox" name="practicePage__enablePerformanceRecording" bind:checked={$practicePage__enablePerformanceRecording}>
+            <label for="practiceActivities__enablePerformanceRecording">Record Performances</label>
+            <input type="checkbox" name="practiceActivities__enablePerformanceRecording" bind:checked={$practiceActivities__enablePerformanceRecording}>
         </div>
         <div>
             <label for="danceVideoVolume">Dance Video Volume</label>

--- a/svelte-web-frontend/src/lib/pages/SettingsPage.svelte
+++ b/svelte-web-frontend/src/lib/pages/SettingsPage.svelte
@@ -18,6 +18,7 @@ import {
     useAIFeedback,
     evaluation_summarizeSubsections,
     evaluation_summarizeSubsectionsOptions,
+    metric__3dskeletonsimilarity__badJointStdDeviationThreshold,
 	useTextToSpeech,
 	practiceFallbackPlaybackSpeed,
     practicePage__enablePerformanceRecording,
@@ -93,14 +94,6 @@ function clearPerformanceHistory() {
             <label for="debugPauseDuration">Debug Pause Duration</label>
             <input class="outlined thin" type="number" name="debugPauseDuration" bind:value={$debugPauseDurationSecs} min={pauseDurationMin} max={pauseDurationMax} step={pauseDurationStep}>
         </div>
-        <div>
-            <label for="feedback_YellowThreshold">Live Feedback - Yellow Threshold</label>
-            <input class="outlined thin" type="number" name="feedback_YellowThreshold" bind:value={$feedback_YellowThreshold} min={qijiaScoreMin} max={qijiaScoreMax} step={0.1}>
-        </div>
-        <div>
-            <label for="feedback_GreenThreshold">Live Feedback - Green Threshold</label>
-            <input class="outlined thin" type="number" name="feedback_GreenThreshold" bind:value={$feedback_GreenThreshold} min={qijiaScoreMin} max={qijiaScoreMax} step={0.1}>
-        </div>
         {/if}
         <div>
             <label for="practicePage__enablePerformanceRecording">Record Performances</label>
@@ -128,14 +121,6 @@ function clearPerformanceHistory() {
             <input class="outlined thin" type="number" name="evaluation_GoodBadTrialThreshold" disabled={$useAIFeedback} bind:value={$evaluation_GoodBadTrialThreshold} min={qijiaScoreMin} max={qijiaScoreMax} step={0.1}>
         </div>
         <div>
-            <label for="summaryFeedback_skeleton3d_mediumPerformanceThreshold">3D Angle - Yellow Threshold</label>
-            <input class="outlined thin" type="number" name="summaryFeedback_skeleton3d_mediumPerformanceThreshold" bind:value={$summaryFeedback_skeleton3d_mediumPerformanceThreshold} min={0} max={1} step={0.01}>
-        </div>
-        <div>
-            <label for="summaryFeedback_skeleton3d_goodPerformanceThreshold">3D Angle - Green Threshold</label>
-            <input class="outlined thin" type="number" name="summaryFeedback_skeleton3d_goodPerformanceThreshold" bind:value={$summaryFeedback_skeleton3d_goodPerformanceThreshold} min={0} max={1} step={0.01}>
-        </div>
-        <div>
             <label for="evaluation_summarizeSubsections">Evaluate Subsections</label>
             <select class="outlined thin" name="evaluation_summarizeSubsections" bind:value={$evaluation_summarizeSubsections}>
                 {#each Object.entries(evaluation_summarizeSubsectionsOptions) as [optionValue, optionTitle]}
@@ -143,6 +128,42 @@ function clearPerformanceHistory() {
                 {/each}
             </select>
         </div>
+    </div>
+    <div class="group">
+        <h3>Metrics Parameters</h3>
+        <details>
+            <summary>3D Skeleton Joint Angle Similarity</summary>
+            <div class="controlGrid">
+                <label for="metric__3dskeletonsimilarity__badJointStdDeviationThreshold">'Troublsome Joint' Threshold</label>
+                <input class="outlined thin" type="number" name="summaryFeedback_skeleton3d_mediumPerformanceThreshold" bind:value={$metric__3dskeletonsimilarity__badJointStdDeviationThreshold} min={0} max={3.0} step={0.05}>
+                <span class="note">
+                    Used to determine which joints get 
+                    reported to the LLM as "troublesome joints"
+                </span>
+
+                <label for="summaryFeedback_skeleton3d_mediumPerformanceThreshold">3D Angle - Yellow Threshold</label>
+                <input class="outlined thin" type="number" name="summaryFeedback_skeleton3d_mediumPerformanceThreshold" bind:value={$summaryFeedback_skeleton3d_mediumPerformanceThreshold} min={0} max={1} step={0.01}>
+                <span class="note">This is used for bar coloring</span>
+
+                <label for="summaryFeedback_skeleton3d_goodPerformanceThreshold">3D Angle - Green Threshold</label>
+                <input class="outlined thin" type="number" name="summaryFeedback_skeleton3d_goodPerformanceThreshold" bind:value={$summaryFeedback_skeleton3d_goodPerformanceThreshold} min={0} max={1} step={0.01}>
+                <span class="note">This is used for bar coloring</span>
+            </div>
+        </details>
+        <details>
+            <summary>2D Skeleton Vector Similarity (Qijia's Method)</summary>
+            <div class="controlGrid">
+                
+                
+                <label for="feedback_YellowThreshold">Yellow Threshold</label>
+                <input class="outlined thin" type="number" name="feedback_YellowThreshold" bind:value={$feedback_YellowThreshold} min={qijiaScoreMin} max={qijiaScoreMax} step={0.1}>
+                <span class="note">This is used for live feedback color coding</span>
+
+                <label for="feedback_GreenThreshold">Green Threshold</label>
+                <input class="outlined thin" type="number" name="feedback_GreenThreshold" bind:value={$feedback_GreenThreshold} min={qijiaScoreMin} max={qijiaScoreMax} step={0.1}>
+                <span class="note">This is used for live feedback color coding</span>
+            </div>
+        </details>
     </div>
     <div>
         <button class="button" disabled={Object.keys($frontendPerformanceHistory).length === 0} on:click={clearPerformanceHistory}>Clear Performance History</button>
@@ -184,11 +205,53 @@ div.group {
 }
 
 
-div.group > div {
+div.group > div, details > div {
     display: flex;
     flex-direction: row;
     align-items: center;
     gap: 0.5rem;
+}
+
+details {
+    margin: 0.5em auto;
+    text-align: center;
+}
+
+details summary {
+    cursor: pointer;
+
+    &:hover {
+        text-decoration: underline;
+    }
+}
+
+.note {
+    font-size: 0.8em;
+    color: gray;
+    margin-top: -0.6em;
+    margin-bottom: 0.25em;
+    white-space: pre-line;
+}  
+
+.controlGrid {
+    font-size: 0.8em;
+    margin: 0.5em auto;
+    display: inline-grid;
+    grid-template-columns: auto 1fr;
+}
+
+.controlGrid label {
+    grid-column: 1;
+    justify-self: flex-end;
+    align-self: center;
+}
+.controlGrid input {
+    grid-column: 2;
+    justify-self: flex-start;
+    align-self: center;
+}
+.controlGrid .note {
+    grid-column: 1 / span 2;
 }
 
 input[type=number] {

--- a/svelte-web-frontend/src/routes/styles.scss
+++ b/svelte-web-frontend/src/routes/styles.scss
@@ -1,6 +1,6 @@
-@import url('https://fonts.googleapis.com/css2?family=Grandstander:wght@100;200;400;600&display=swap');
-@import url(https://fonts.googleapis.com/css?family=Patrick+Hand+SC);
-@import url('https://fonts.googleapis.com/css2?family=Recursive:wght,CASL,CRSV,MONO@450,1,1,1&display=swap'); 
+// @import url('https://fonts.googleapis.com/css2?family=Grandstander:wght@100;200;400;600&display=swap');
+// @import url(https://fonts.googleapis.com/css?family=Patrick+Hand+SC);
+// @import url('https://fonts.googleapis.com/css2?family=Recursive:wght,CASL,CRSV,MONO@450,1,1,1&display=swap'); 
 // @import '@fontsource/fira-mono';
 // @import 'simple-grid.scss';
 
@@ -8,9 +8,10 @@
 
 :root {
 	/* --font-body: Arial, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu,
-		Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif; */
-	--font-body: 'Grandstander', 'Patrick Hand SC', cursive;
-	--font-mono: 'Recursive', 'Fira Mono', monospace; 
+		Cantarell, , sans-serif; */
+	// --font-body: 'Grandstander', 'Patrick Hand SC', cursive;
+	--font-body: -apple-system, BlinkMacSystemFont, Roboto, Ubuntu, 'Segoe UI', 'Open Sans', 'Helvetica Neue', 'Arial', sans-serif;
+	--font-mono: monospace; 
 	--color-bg-0: rgb(193, 198, 202);
 	--color-bg-1: hsl(209, 14%, 64%);
 	--color-bg-2: hsl(223, 35%, 84%);
@@ -218,6 +219,9 @@ a.button {
 }
 .mb-4 {
 	margin-bottom: 1rem;
+}
+.mt-4 {
+	margin-top: 1rem;
 }
 
 .margin-auto {

--- a/svelte-web-frontend/src/routes/styles.scss
+++ b/svelte-web-frontend/src/routes/styles.scss
@@ -4,8 +4,6 @@
 // @import '@fontsource/fira-mono';
 // @import 'simple-grid.scss';
 
-
-
 :root {
 	/* --font-body: Arial, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu,
 		Cantarell, , sans-serif; */
@@ -20,7 +18,7 @@
 	--color-theme-1: var(--color-blue);
 	--color-theme-2: #var(--color-red);
 	--color-text: rgba(0, 0, 0, 0.7);
-	--color-text-disabled: rgba(100, 100, 100, 0.5);
+	--coxlor-text-disabled: rgba(100, 100, 100, 0.5);
 	--color-text-label: rgba(50, 50, 50, 0.6);
 	
 	--max-line-width: 50ch;
@@ -293,6 +291,10 @@ div.spinner {
 .flex-crossaxis-center {
 	align-items: center;
 }
+.flex-crossaxis-end {
+	align-items: flex-end;
+}
+
 .flex-center {
 	justify-content: center;
 	align-items: center;

--- a/svelte-web-frontend/src/routes/styles.scss
+++ b/svelte-web-frontend/src/routes/styles.scss
@@ -21,6 +21,7 @@
 	--color-theme-2: #var(--color-red);
 	--color-text: rgba(0, 0, 0, 0.7);
 	--color-text-disabled: rgba(100, 100, 100, 0.5);
+	--color-text-label: rgba(50, 50, 50, 0.6);
 	
 	--max-line-width: 50ch;
 	// --std-border-radius: 1rem;
@@ -41,6 +42,13 @@ body {
 		rgba(255, 255, 255, 0) 100%
 	);
 	background-image: var(--radial-focusing-gradient), linear-gradient(180deg, var(--color-bg-0) 0%, var(--color-bg-1) 15%, var(--color-bg-2) 50%);
+}
+
+.text-disabled {
+	color: var(--color-text-disabled)
+}
+.text-label {
+	color: var(--color-text-label);
 }
 
 h1,

--- a/svelte-web-frontend/src/routes/teachlesson/[danceTreeId]/+page.svelte
+++ b/svelte-web-frontend/src/routes/teachlesson/[danceTreeId]/+page.svelte
@@ -2,12 +2,14 @@
 import DanceTreePage from "$lib/pages/DanceTreePage.svelte";
 import type { DanceTree, Dance } from '$lib/data/dances-store';
 import { navbarProps } from "$lib/elements/NavBar.svelte";
+	import { browser } from "$app/environment";
+	import { navigating } from "$app/stores";
 
 /** @type {import('./$types').PageData} */    
 export let data;
 const dance: Dance = data.dance;
 const danceTree: DanceTree = data.danceTree;
-
+const preselectedNodeId = data.preselectedNodeId;
 $: {
 	navbarProps.set({
 		collapsed: false,
@@ -19,11 +21,19 @@ $: {
 	});
 }
 
+function updateQueryParams(selectedNodeId: string) {
+	// TODO: update search query parameters, so that user will 
+	//       see the selected node persist upon a refresh.
+}
 </script>
 
 <svelte:head>
-	<title>{dance.title} (Preview)</title>
+	<title>{dance.title} (Preview) ({preselectedNodeId})</title>
 	<meta name="description" content="App for learning the dance: {dance.title}" />
 </svelte:head>
 
-<DanceTreePage {dance} {danceTree} />
+<DanceTreePage 
+	{dance} 
+	{danceTree}
+	preselectedNodeId={preselectedNodeId}
+	on:selected-node={(e) => updateQueryParams(e.detail)} />

--- a/svelte-web-frontend/src/routes/teachlesson/[danceTreeId]/+page.ts
+++ b/svelte-web-frontend/src/routes/teachlesson/[danceTreeId]/+page.ts
@@ -3,7 +3,7 @@ import { error } from '@sveltejs/kit';
 import { getDanceAndDanceTreeFromDanceTreeId } from '$lib/data/dances-store.js';
 
 /** @type {import('./$types').PageLoad} */
-export function load({ params })  {
+export function load({ url, params })  {
 
     const danceTreeId: string = params.danceTreeId;
     const [dance, danceTree] = getDanceAndDanceTreeFromDanceTreeId(danceTreeId);
@@ -15,9 +15,12 @@ export function load({ params })  {
         throw  error(404, 'Dance Tree Not found');   
     }
 
+    const preselectedNodeId = url.searchParams.get('preselectedNodeId');
+
     return {
         dance: dance,
-        danceTree: danceTree
+        danceTree: danceTree,
+        preselectedNodeId: preselectedNodeId,
     }
 }
 

--- a/svelte-web-frontend/src/routes/teachlesson/[danceTreeId]/practicenode/[practiceNodeId]/+page.svelte
+++ b/svelte-web-frontend/src/routes/teachlesson/[danceTreeId]/practicenode/[practiceNodeId]/+page.svelte
@@ -18,7 +18,7 @@ const playbackSpeed: number = data.playbackSpeed ?? $practiceActivities__playbac
 
 const interfaceMode: PracticeInterfaceModeKey = data.interfaceMode;
 const terminalFeedbackEnabled: boolean = data.terminalFeedbackEnabled;
-const userSkeletonColorCodingEnabled: boolean = data.userSkeletonColorCodingEnabled;
+const showUserSkeleton: boolean = data.showUserSkeleton;
 
 let { activity, url } = GeneratePracticeActivity(
     dance,
@@ -28,7 +28,7 @@ let { activity, url } = GeneratePracticeActivity(
         playbackSpeed,
         interfaceMode,
         terminalFeedbackEnabled,
-        userSkeletonColorCodingEnabled,
+        showUserSkeleton: showUserSkeleton,
     }
 )
 let practiceActivity: PracticeActivity = activity;

--- a/svelte-web-frontend/src/routes/teachlesson/[danceTreeId]/practicenode/[practiceNodeId]/+page.svelte
+++ b/svelte-web-frontend/src/routes/teachlesson/[danceTreeId]/practicenode/[practiceNodeId]/+page.svelte
@@ -7,26 +7,27 @@ import { INITIAL_STATE, type PracticePageState } from '$lib/pages/PracticePage.s
 import { navbarProps } from '$lib/elements/NavBar.svelte';
 import type PracticeActivity from '$lib/model/PracticeActivity';
 import type { PracticeInterfaceModeKey } from '$lib/model/PracticeActivity';
+	import { practiceFallbackPlaybackSpeed } from '$lib/model/settings';
 
 /** @type {import('./$types').PageData} */    
 export let data;
 const dance: Dance = data.dance;
 const danceTree: DanceTree = data.danceTree;
 const danceTreeNode: DanceTreeNode = data.danceTreeNode;
-const playbackSpeed: number = data.playbackSpeed;
+const playbackSpeed: number = data.playbackSpeed ?? $practiceFallbackPlaybackSpeed; 
 
-const interfaceModeKey: PracticeInterfaceModeKey = data.interfaceMode;
+const interfaceMode: PracticeInterfaceModeKey = data.interfaceMode;
 const terminalFeedbackEnabled: boolean = data.terminalFeedbackEnabled;
-const enableUserSkeletonColorCoding: boolean = data.enableUserSkeletonColorCoding;
+const userSkeletonColorCodingEnabled: boolean = data.userSkeletonColorCodingEnabled;
 
 let { activity, url } = GeneratePracticeActivity({
     dance,
     danceTree,
     danceTreeNode,
     playbackSpeed,
-    interfaceMode: interfaceModeKey,
+    interfaceMode,
     terminalFeedbackEnabled,
-    enableUserSkeletonColorCoding,
+    userSkeletonColorCodingEnabled,
 })
 let practiceActivity: PracticeActivity = activity;
 

--- a/svelte-web-frontend/src/routes/teachlesson/[danceTreeId]/practicenode/[practiceNodeId]/+page.svelte
+++ b/svelte-web-frontend/src/routes/teachlesson/[danceTreeId]/practicenode/[practiceNodeId]/+page.svelte
@@ -7,28 +7,30 @@ import { INITIAL_STATE, type PracticePageState } from '$lib/pages/PracticePage.s
 import { navbarProps } from '$lib/elements/NavBar.svelte';
 import type PracticeActivity from '$lib/model/PracticeActivity';
 import type { PracticeInterfaceModeKey } from '$lib/model/PracticeActivity';
-	import { practiceFallbackPlaybackSpeed } from '$lib/model/settings';
+	import { practiceActivities__playbackSpeed } from '$lib/model/settings';
 
 /** @type {import('./$types').PageData} */    
 export let data;
 const dance: Dance = data.dance;
 const danceTree: DanceTree = data.danceTree;
 const danceTreeNode: DanceTreeNode = data.danceTreeNode;
-const playbackSpeed: number = data.playbackSpeed ?? $practiceFallbackPlaybackSpeed; 
+const playbackSpeed: number = data.playbackSpeed ?? $practiceActivities__playbackSpeed; 
 
 const interfaceMode: PracticeInterfaceModeKey = data.interfaceMode;
 const terminalFeedbackEnabled: boolean = data.terminalFeedbackEnabled;
 const userSkeletonColorCodingEnabled: boolean = data.userSkeletonColorCodingEnabled;
 
-let { activity, url } = GeneratePracticeActivity({
+let { activity, url } = GeneratePracticeActivity(
     dance,
     danceTree,
     danceTreeNode,
-    playbackSpeed,
-    interfaceMode,
-    terminalFeedbackEnabled,
-    userSkeletonColorCodingEnabled,
-})
+    {
+        playbackSpeed,
+        interfaceMode,
+        terminalFeedbackEnabled,
+        userSkeletonColorCodingEnabled,
+    }
+)
 let practiceActivity: PracticeActivity = activity;
 
 let parentURL: string;

--- a/svelte-web-frontend/src/routes/teachlesson/[danceTreeId]/practicenode/[practiceNodeId]/+page.svelte
+++ b/svelte-web-frontend/src/routes/teachlesson/[danceTreeId]/practicenode/[practiceNodeId]/+page.svelte
@@ -5,21 +5,30 @@ import { makeDanceTreeSlug, type DanceTree, type Dance, type DanceTreeNode } fro
 import PracticePage from '$lib/pages/PracticePage.svelte';
 import { INITIAL_STATE, type PracticePageState } from '$lib/pages/PracticePage.svelte';
 import { navbarProps } from '$lib/elements/NavBar.svelte';
+import type PracticeActivity from '$lib/model/PracticeActivity';
+import type { PracticeInterfaceModeKey } from '$lib/model/PracticeActivity';
 
 /** @type {import('./$types').PageData} */    
 export let data;
 const dance: Dance = data.dance;
 const danceTree: DanceTree = data.danceTree;
-const node: DanceTreeNode = data.danceTreeNode;
+const danceTreeNode: DanceTreeNode = data.danceTreeNode;
 const playbackSpeed: number = data.playbackSpeed;
 
-let practiceActivity = GeneratePracticeActivity (
+const interfaceModeKey: PracticeInterfaceModeKey = data.interfaceMode;
+const terminalFeedbackEnabled: boolean = data.terminalFeedbackEnabled;
+const enableUserSkeletonColorCoding: boolean = data.enableUserSkeletonColorCoding;
+
+let { activity, url } = GeneratePracticeActivity({
     dance,
     danceTree,
-    node,
+    danceTreeNode,
     playbackSpeed,
-    // {} //  UserDancePerformanceLog
-)
+    interfaceMode: interfaceModeKey,
+    terminalFeedbackEnabled,
+    enableUserSkeletonColorCoding,
+})
+let practiceActivity: PracticeActivity = activity;
 
 let parentURL = "/teachlesson/" + makeDanceTreeSlug(danceTree)
 $: {
@@ -36,7 +45,7 @@ $: {
 $: {
     navbarProps.set({
         collapsed: hideNavBar,
-        pageTitle: `${dance.title}: ${node.id}`,
+        pageTitle: `${dance.title}: ${danceTreeNode.id}`,
         back: {
             url: parentURL,
             title: 'Back',
@@ -47,8 +56,8 @@ $: {
 </script>
 
 <svelte:head>
-	<title>{dance.title} '{node.id}' Practice</title>
-	<meta name="description" content="Practice page for section {node.id} of dance: {dance.title}" />
+	<title>{dance.title} '{danceTreeNode.id}' Practice</title>
+	<meta name="description" content="Practice page for section {danceTreeNode.id} of dance: {dance.title}" />
 </svelte:head>
 
 <section>

--- a/svelte-web-frontend/src/routes/teachlesson/[danceTreeId]/practicenode/[practiceNodeId]/+page.svelte
+++ b/svelte-web-frontend/src/routes/teachlesson/[danceTreeId]/practicenode/[practiceNodeId]/+page.svelte
@@ -30,9 +30,9 @@ let { activity, url } = GeneratePracticeActivity({
 })
 let practiceActivity: PracticeActivity = activity;
 
-let parentURL = "/teachlesson/" + makeDanceTreeSlug(danceTree)
+let parentURL: string;
 $: {
-    parentURL = "/teachlesson/" + makeDanceTreeSlug(danceTree)
+    parentURL = `/teachlesson/${makeDanceTreeSlug(danceTree)}?preselectedNodeId=${danceTreeNode.id}`
 }
 let pageState: PracticePageState = INITIAL_STATE;
 

--- a/svelte-web-frontend/src/routes/teachlesson/[danceTreeId]/practicenode/[practiceNodeId]/+page.ts
+++ b/svelte-web-frontend/src/routes/teachlesson/[danceTreeId]/practicenode/[practiceNodeId]/+page.ts
@@ -27,9 +27,9 @@ export async function load({ url, params })  {
         terminalFeedbackEnabled = false;
     }
 
-    let userSkeletonColorCodingEnabled = true;
-    if (url.searchParams.get('userSkeletonColorCodingEnabled') === `${false}`) {
-        userSkeletonColorCodingEnabled = false;
+    let showUserSkeleton = true;
+    if (url.searchParams.get('showUserSkeleton') === `${false}`) {
+        showUserSkeleton = false;
     }
 
     const danceTreeId: string = params.danceTreeId;
@@ -51,7 +51,7 @@ export async function load({ url, params })  {
         playbackSpeed,
         interfaceMode,
         terminalFeedbackEnabled,
-        userSkeletonColorCodingEnabled,
+        showUserSkeleton,
     }
 }
 

--- a/svelte-web-frontend/src/routes/teachlesson/[danceTreeId]/practicenode/[practiceNodeId]/+page.ts
+++ b/svelte-web-frontend/src/routes/teachlesson/[danceTreeId]/practicenode/[practiceNodeId]/+page.ts
@@ -1,6 +1,7 @@
 import { error } from '@sveltejs/kit';
 
 import { getDanceAndDanceTreeFromDanceTreeId, findDanceTreeNode } from '$lib/data/dances-store.js';
+import { PracticeInterfaceModes } from '$lib/model/PracticeActivity';
 
 /** @type {import('./$types').PageLoad} */
 export async function load({ url, params })  {
@@ -13,6 +14,21 @@ export async function load({ url, params })  {
         if (!isNaN(parsedPlaybackSpeed)) {
             playbackSpeed = parsedPlaybackSpeed
         }
+    }
+    let interfaceMode = url.searchParams.get('interfaceMode');
+    if (!interfaceMode || Object.keys(PracticeInterfaceModes).indexOf(interfaceMode) === -1) {
+        interfaceMode = 'bothVideos';
+    }
+    
+    // Default to enabling terminal feedback.
+    let terminalFeedbackEnabled = true;
+    if (url.searchParams.get('terminalFeedbackEnabled') === `${false}`) {
+        terminalFeedbackEnabled = false;
+    }
+
+    let enableUserSkeletonColorCoding = true;
+    if (url.searchParams.get('enableUserSkeletonColorCoding') === `${false}`) {
+        enableUserSkeletonColorCoding = false;
     }
 
     const danceTreeId: string = params.danceTreeId;
@@ -28,10 +44,13 @@ export async function load({ url, params })  {
     const danceTreeNode = findDanceTreeNode(danceTree, params.practiceNodeId);
 
     return {
-        dance: dance,
-        danceTree: danceTree,
-        danceTreeNode: danceTreeNode,
-        playbackSpeed: playbackSpeed,
+        dance,
+        danceTree,
+        danceTreeNode,
+        playbackSpeed,
+        interfaceMode,
+        terminalFeedbackEnabled,
+        enableUserSkeletonColorCoding,
     }
 }
 

--- a/svelte-web-frontend/src/routes/teachlesson/[danceTreeId]/practicenode/[practiceNodeId]/+page.ts
+++ b/svelte-web-frontend/src/routes/teachlesson/[danceTreeId]/practicenode/[practiceNodeId]/+page.ts
@@ -8,13 +8,14 @@ export async function load({ url, params })  {
 
     const playbackSpeedSearchParam = url.searchParams.get('playbackSpeed');
 
-    let playbackSpeed = 'default' as 'default' | number;
+    let playbackSpeed: number | undefined;
     if (playbackSpeedSearchParam) {
         const parsedPlaybackSpeed = parseFloat(playbackSpeedSearchParam);
         if (!isNaN(parsedPlaybackSpeed)) {
             playbackSpeed = parsedPlaybackSpeed
         }
     }
+
     let interfaceMode = url.searchParams.get('interfaceMode');
     if (!interfaceMode || Object.keys(PracticeInterfaceModes).indexOf(interfaceMode) === -1) {
         interfaceMode = 'bothVideos';
@@ -26,9 +27,9 @@ export async function load({ url, params })  {
         terminalFeedbackEnabled = false;
     }
 
-    let enableUserSkeletonColorCoding = true;
-    if (url.searchParams.get('enableUserSkeletonColorCoding') === `${false}`) {
-        enableUserSkeletonColorCoding = false;
+    let userSkeletonColorCodingEnabled = true;
+    if (url.searchParams.get('userSkeletonColorCodingEnabled') === `${false}`) {
+        userSkeletonColorCodingEnabled = false;
     }
 
     const danceTreeId: string = params.danceTreeId;
@@ -50,7 +51,7 @@ export async function load({ url, params })  {
         playbackSpeed,
         interfaceMode,
         terminalFeedbackEnabled,
-        enableUserSkeletonColorCoding,
+        userSkeletonColorCodingEnabled,
     }
 }
 


### PR DESCRIPTION
This PR adds the ability for the user to select UI options for their dance practicing. The supported options are:
* (preexisting) Practice speed
* (new) UI arrangement (demo video, virtual mirror, or both)
* Whether or not to show the live feedback skeletons
* Whether or not the system should provide feedback at the end.

These options are saved as settings, so they're persistent.

![image](https://github.com/j55blanchet/dance-teacher-xr-unity/assets/4062772/853a1fde-0200-4308-9957-12269fa3a69c)

Practicing a section with just the demo video looks like this:
![image](https://github.com/j55blanchet/dance-teacher-xr-unity/assets/4062772/bb60e5f2-fc09-4f48-b774-b885d0b8f40c)


You can also adjust the practice configuration from the feedback screen:
![Screen Shot 2023-10-28 at 22 20 19](https://github.com/j55blanchet/dance-teacher-xr-unity/assets/4062772/84e4c426-14a6-4bb9-a916-1e82b3ab2fcf)

![image](https://github.com/j55blanchet/dance-teacher-xr-unity/assets/4062772/8599cb33-22bf-4a77-9bad-9e05acde6328)


