### PR TITLE
Add validated cloud motion pipeline workflow

### DIFF
--- a/documentation/dataset.md
+++ b/documentation/dataset.md
@@ -66,6 +66,20 @@ The Python wrapper `python -m motion_extraction.rclone_transfer` provides corres
 
 `rclone sync` is intentionally reserved for publishing a validated processed-media bundle. Use `copy` for ordinary inputs and research artifacts.
 
+The complete reference-video workflow is available from
+`motion-pipeline/script_invocations/run_rclone_pipeline.sh`. It stages a
+selected `dataset:` subtree into a local run directory, invokes the existing
+path-based DanceTree pipeline, and validates the database, raw pose, clean pose,
+complexity, audio, enriched DanceTree, and bundle outputs after each stage. A
+`run-manifest.json` records the remote source, parameters, and validated stages.
+
+Processed media is promoted separately with
+`motion-pipeline/script_invocations/publish_processed_media.sh --confirm
+<local-bundle-media-dir>`. This calls `rclone sync` against
+`processedmediabundle:` and can delete stale remote cache files; it is never
+invoked by the processing runner. Do not publish until the frontend has
+validated the generated bundle.
+
 ## Publishing rules
 
 - Publish only outputs that are complete enough to survive beyond the current run.

--- a/lab-log/2026-08-08-mediapipe-macos-smoke-fix.md
+++ b/lab-log/2026-08-08-mediapipe-macos-smoke-fix.md
@@ -1,0 +1,33 @@
+---
+date: 2026-08-08
+tags: [motion-pipeline, mediapipe, macos, smoke-tests]
+artifacts: []
+---
+
+# MediaPipe macOS smoke-gate fix
+
+## Findings
+
+- MediaPipe 1.0.0's `HolisticLandmarker` aborts during graph creation on this
+  macOS environment with `DrishtiMetalHelper` reporting that its graph service
+  is unavailable. Selecting the CPU delegate and setting
+  `MEDIAPIPE_DISABLE_GPU=1` did not prevent that native path.
+- MediaPipe 0.10.21 remains Tasks-API compatible and creates the Holistic task
+  successfully. Its task detector still aborts on an empty output packet for
+  the smoke input, so it is not safe to use for this batch extractor yet.
+- The 0.10.21 `mediapipe.python.solutions.holistic.Holistic` implementation
+  completes the pose-extraction and full-pipeline smoke tests in the desktop
+  execution context. Its graph uses the macOS OpenGL service even though the
+  inference graph is the CPU variant.
+- A direct 0.10.21 Tasks GPU probe successfully created the Metal delegate but
+  then aborted on an empty landmark packet. GPU inference is therefore not
+  enabled by default until a task-runtime/model combination handles missing
+  landmarks safely.
+
+## Decision
+
+Pin the motion pipeline to `mediapipe==0.10.21`, preserve the Tasks-compatible
+runtime and helper APIs, and use the stable Holistic batch path for extraction.
+The full smoke gate passes 11/11 in the desktop execution context. GPU support
+remains an explicit follow-up rather than a default that can terminate a
+research-data run.

--- a/motion-pipeline/README.md
+++ b/motion-pipeline/README.md
@@ -34,7 +34,12 @@ This creates `motion-pipeline/.venv`. In VS Code, open [the repository multi-roo
 
 The support target is Python 3.10 on macOS (Apple Silicon) and Linux (x86_64); this baseline has been clean-install validated on macOS, with Linux validation delegated to the follow-on CI step. Windows and the legacy robotics stack remain unverified; install the latter explicitly with `uv sync --group legacy-robotics` when working on it. `ffmpeg` is required for the active video/audio workflow, while `rclone` is needed only for cloud-transfer commands.
 
-`mediapipe==1.0.0` is deliberate: the active pipeline uses MediaPipe Tasks APIs, including `HolisticLandmarker` for holistic extraction and `PoseLandmarker` for pose-only workflows. The legacy `mediapipe.solutions` API is not used.
+`mediapipe==0.10.21` is deliberate: it includes the MediaPipe Tasks APIs and
+the Holistic implementation needed by this project. The 1.0.0 Holistic task
+graph aborts on macOS when its Metal service is unavailable, while the 0.10.21
+batch path completes the smoke suite. The batch extractor therefore uses the
+stable 0.10.21 Holistic API; task-based helpers remain available for pose and
+GPU experiments.
 
 The Holistic Landmarker task needs one model asset that is not bundled in the
 Python wheel. Prepare it explicitly before running pose extraction:
@@ -126,6 +131,39 @@ uv run --locked python -m motion_extraction.rclone_transfer publish-processed-bu
 ```
 
 The processed-bundle publication command replaces the cache and should run only after frontend validation. See [the dataset guide](../documentation/dataset.md).
+
+### Full staged reference-video run
+
+For a full dataset run, stage a Drive subtree locally, process only local paths,
+and validate every pipeline stage before the command succeeds:
+
+```bash
+./script_invocations/run_rclone_pipeline.sh \
+  --remote-path referencevideos \
+  --run-dir /private/tmp/motion-pipeline-reference-run \
+  --include-audio-in-bundle \
+  --include-thumbnail-in-bundle
+```
+
+The command uses `rclone copy dataset:<remote-path> ...`, then writes the
+generated database, pose data, analysis outputs, bundle, and artifact archive
+under `<run-dir>/output/`. It writes `<run-dir>/run-manifest.json` only after
+all seven stages have passed their output contracts. Reusing a run directory is
+supported for pipeline caching; use a new directory when an isolated snapshot
+is required.
+
+After validating the generated media in the frontend, publication is a separate
+explicit operation. It replaces the remote processed-media cache, so the
+guarded script requires `--confirm`:
+
+```bash
+./script_invocations/publish_processed_media.sh \
+  --confirm \
+  /private/tmp/motion-pipeline-reference-run/output/bundle/media
+```
+
+Do not run this publication command until the bundle has been reviewed. The
+pipeline runner never publishes automatically.
 
 ## Useful entry points
 

--- a/motion-pipeline/motion_extraction/dancetree/run_dancetree_pipeline.py
+++ b/motion-pipeline/motion_extraction/dancetree/run_dancetree_pipeline.py
@@ -47,8 +47,10 @@ def run_dancetree_pipeline(
     suppress_audio_analysis_artifacts: bool = False,
     suppress_add_complexity_artifacts: bool = False,
     suppress_bundle_data_artifacts: bool = False,
+    stage_validator: t.Optional[t.Callable[[str], None]] = None,
 
 ):
+    """Run the reference-video pipeline and optionally validate each stage."""
     complexities_temp_dir = temp_dir / 'complexities'
     audio_results_temp_dir = temp_dir / 'audio_analysis'
     audio_analysis_tree_dir = _audio_result_subdirectory(
@@ -116,6 +118,8 @@ def run_dancetree_pipeline(
         replace_existing_thumbnails=False,
         artifact_output_dir=get_step_artifact_dir("01-update-database", suppress_update_database_artifacts),
     )
+    if stage_validator is not None:
+        stage_validator("update-database")
 
     current_step += 1
     extract_holistic_data(
@@ -128,6 +132,8 @@ def run_dancetree_pipeline(
         print_prefix=lambda: f'{step()} extract raw pose data:',
         artifact_output_dir=get_step_artifact_dir("02-extract-pose-data", suppress_compute_holistic_data_artifacts),
     )
+    if stage_validator is not None:
+        stage_validator("extract-pose-data")
 
     current_step += 1
     preprocess_all_pose_data(
@@ -137,6 +143,8 @@ def run_dancetree_pipeline(
         print_prefix=lambda: f'{step()} preprocess pose data:',
         artifact_output_dir=get_step_artifact_dir("03-preprocess-pose-data", suppress_preprocess_pose_data_artifacts),
     )
+    if stage_validator is not None:
+        stage_validator("preprocess-pose-data")
 
     current_step += 1
     complexity_pose_data_root = (
@@ -163,6 +171,8 @@ def run_dancetree_pipeline(
         print_prefix=lambda: f'{step()} calc. complexity:',
         skip_existing=skip_existing_cumulative_complexity,
     )
+    if stage_validator is not None:
+        stage_validator("cumulative-complexity")
     
     current_step += 1
     if skip_existing_audioanalysis and audio_analysis_tree_dir.exists() and (audio_results_temp_dir / 'audio_analysis_summary.csv').exists():
@@ -182,6 +192,8 @@ def run_dancetree_pipeline(
             print_prefix=lambda: f'{step()} audio analysis:',
             artifact_output_dir=get_step_artifact_dir("05-audio-analysis", suppress_audio_analysis_artifacts),
         )
+    if stage_validator is not None:
+        stage_validator("audio-analysis")
 
     current_step += 1
     add_complexities_to_dancetrees(
@@ -194,6 +206,8 @@ def run_dancetree_pipeline(
         get_print_prefix=lambda: f'{step()} add complexity:',
         artifact_output_dir=get_step_artifact_dir("06-add-complexity", suppress_add_complexity_artifacts),
     )
+    if stage_validator is not None:
+        stage_validator("add-complexity")
 
     current_step += 1
     bundle_dance_data_as_json(
@@ -205,6 +219,8 @@ def run_dancetree_pipeline(
         print_prefix=lambda: f'{step()} bundle data:',
         artifact_output_dir=get_step_artifact_dir("07-bundle-data", suppress_bundle_data_artifacts),
     )
+    if stage_validator is not None:
+        stage_validator("bundle-data")
 
 if __name__ == "__main__":
     import argparse

--- a/motion-pipeline/motion_extraction/extract_holistic_data.py
+++ b/motion-pipeline/motion_extraction/extract_holistic_data.py
@@ -14,18 +14,13 @@ from .artifacts import build_artifact_report, resolve_artifact_output_dir
 from .utils import throttle
 from .mp_utils import (
 	HAND_CONNECTIONS,
-	HOLISTIC_LANDMARKER_MODEL_URL,
 	POSE_CONNECTIONS,
 	HandLandmark,
 	PoseLandmark,
-	build_base_options,
-	ensure_task_model,
-	holistic_landmarker_model_path,
 	landmark_at,
 	landmark_list,
-	rgb_image_to_mp_image,
 )
-from mediapipe.tasks.python import vision
+from mediapipe.python.solutions import holistic as mp_holistic
 
 import mpl_toolkits.mplot3d.art3d as art3d
 from mpl_toolkits.mplot3d.axes3d import Axes3D
@@ -427,27 +422,16 @@ def process_video(
 
 	with (
 		holistic_data_output_filepath.open('w', encoding='utf-8', newline='') as holistic_file,
-		vision.HolisticLandmarker.create_from_options(
-			vision.HolisticLandmarkerOptions(
-				base_options=build_base_options(
-					ensure_task_model(
-						holistic_landmarker_model_path(),
-						HOLISTIC_LANDMARKER_MODEL_URL,
-					),
-					# MediaPipe 1.0.0's Holistic graph is not compatible with
-					# the Metal delegate on Apple Silicon; CPU is the portable
-					# and reliable batch-extraction path.
-					use_gpu=False,
-				),
-				running_mode=vision.RunningMode.IMAGE,
-				output_face_blendshapes=False,
-				output_segmentation_mask=False,
-			)
+		mp_holistic.Holistic(
+			static_image_mode=True,
+			model_complexity=model_complexity,
+			refine_face_landmarks=False,
+			enable_segmentation=False,
 		) as holistic_processor,
 	):
 		holistic_csv_writer = csv.writer(holistic_file)
 		for frame_i, (_, frame_count, _timestamp_ms, image) in enumerate(_perform_by_frame(input_video_path)):
-			frame_data: t.Any = holistic_processor.detect(rgb_image_to_mp_image(image))
+			frame_data: t.Any = holistic_processor.process(image)
 
 
 			# cv2.imshow(f'Frame {frame_i}', image)

--- a/motion-pipeline/motion_extraction/mp_utils.py
+++ b/motion-pipeline/motion_extraction/mp_utils.py
@@ -9,10 +9,13 @@ import mediapipe as mp
 import numpy as np
 from mediapipe.tasks.python import BaseOptions, vision
 
-# MediaPipe 1.0.0 no longer exposes the legacy `mp.solutions` namespace.
-# Keep this alias so the CSV schema and downstream analysis retain their
-# established landmark names and indices.
-PoseLandmark = vision.PoseLandmark
+# MediaPipe 0.10.x exposes the pose enum through the legacy namespace, while
+# MediaPipe 1.x exposes it from Tasks. Keep the alias local so the CSV schema
+# and downstream analysis retain their established landmark names and indices.
+if hasattr(vision, "PoseLandmark"):
+    PoseLandmark = vision.PoseLandmark
+else:
+    PoseLandmark = mp.solutions.pose.PoseLandmark
 
 
 class HandLandmark(enum.IntEnum):

--- a/motion-pipeline/motion_extraction/pipeline_validation.py
+++ b/motion-pipeline/motion_extraction/pipeline_validation.py
@@ -1,0 +1,231 @@
+"""Validation helpers for the reference-video motion pipeline outputs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import json
+from pathlib import Path
+import typing as t
+
+import pandas as pd
+
+
+class PipelineValidationError(RuntimeError):
+    """Raised when a pipeline stage does not produce its documented outputs."""
+
+
+@dataclass(frozen=True)
+class PipelineOutputLayout:
+    """Describe the paths used by one local DanceTree pipeline run."""
+
+    database_csv_path: Path
+    video_srcdir: Path
+    holistic_data_srcdir: Path
+    pose2d_data_srcdir: Path
+    temp_dir: Path
+    bundle_export_path: Path
+    bundle_media_export_path: Path
+
+    def video_stems(self) -> tuple[Path, ...]:
+        """Return input video stems using the pipeline's relative path convention."""
+
+        videos = sorted(
+            path for path in self.video_srcdir.rglob("*.mp4") if path.is_file()
+        )
+        return tuple(
+            path.relative_to(self.video_srcdir).with_suffix("") for path in videos
+        )
+
+
+@dataclass
+class PipelineOutputValidator:
+    """Validate each stage of a local pipeline run as it completes."""
+
+    layout: PipelineOutputLayout
+    validated_stages: list[str] = field(default_factory=list)
+
+    def __call__(self, stage: str) -> None:
+        """Validate ``stage`` and remember it for run metadata."""
+
+        validate_stage_outputs(stage, self.layout)
+        self.validated_stages.append(stage)
+
+
+def _require_file(path: Path, stage: str) -> None:
+    if not path.is_file() or path.stat().st_size == 0:
+        raise PipelineValidationError(
+            f"{stage}: expected a non-empty file at {path}"
+        )
+
+
+def _require_csv(
+    path: Path,
+    stage: str,
+    *,
+    required_columns: t.Iterable[str] = (),
+    min_rows: int = 1,
+) -> pd.DataFrame:
+    _require_file(path, stage)
+    try:
+        dataframe = pd.read_csv(path)
+    except Exception as error:
+        raise PipelineValidationError(f"{stage}: could not read CSV {path}: {error}") from error
+
+    missing_columns = sorted(set(required_columns) - set(dataframe.columns))
+    if missing_columns:
+        raise PipelineValidationError(
+            f"{stage}: CSV {path} is missing columns {missing_columns}"
+        )
+    if len(dataframe.index) < min_rows:
+        raise PipelineValidationError(
+            f"{stage}: CSV {path} has {len(dataframe.index)} rows; expected at least {min_rows}"
+        )
+    return dataframe
+
+
+def _require_json(path: Path, stage: str) -> t.Any:
+    _require_file(path, stage)
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception as error:
+        raise PipelineValidationError(f"{stage}: could not read JSON {path}: {error}") from error
+
+
+def _expected_path(root: Path, stem: Path, suffix: str) -> Path:
+    """Build an output path while preserving a video's relative directories."""
+
+    return root / Path(f"{stem.as_posix()}{suffix}")
+
+
+def _require_expected_files(
+    root: Path,
+    stems: t.Iterable[Path],
+    suffix: str,
+    stage: str,
+) -> list[Path]:
+    paths = [_expected_path(root, stem, suffix) for stem in stems]
+    for path in paths:
+        _require_file(path, stage)
+    return paths
+
+
+def _validate_database(layout: PipelineOutputLayout, stems: tuple[Path, ...]) -> None:
+    database = _require_csv(
+        layout.database_csv_path,
+        "update-database",
+        required_columns=("clipRelativeStem", "frameCount", "fps"),
+        min_rows=len(stems),
+    )
+    if len(database.index) != len(stems):
+        raise PipelineValidationError(
+            "update-database: database row count does not match the number of input videos "
+            f"({len(database.index)} != {len(stems)})"
+        )
+    expected_stems = {stem.as_posix() for stem in stems}
+    actual_stems = set(database["clipRelativeStem"].astype(str))
+    if actual_stems != expected_stems:
+        raise PipelineValidationError(
+            "update-database: database clipRelativeStem values do not match input videos"
+        )
+
+
+def _validate_pose_outputs(layout: PipelineOutputLayout, stems: tuple[Path, ...], *, clean: bool) -> None:
+    stage = "preprocess-pose-data" if clean else "extract-pose-data"
+    holistic_suffix = ".holisticdata.clean.csv" if clean else ".holisticdata.raw.csv"
+    pose2d_suffix = ".pose2d.clean.csv" if clean else ".pose2d.raw.csv"
+    holistic_paths = _require_expected_files(
+        layout.holistic_data_srcdir, stems, holistic_suffix, stage
+    )
+    pose2d_paths = _require_expected_files(layout.pose2d_data_srcdir, stems, pose2d_suffix, stage)
+
+    if clean:
+        required_columns = {"preprocess_torso_length", "preprocess_is_usable"}
+        for path in [*holistic_paths, *pose2d_paths]:
+            columns = set(_require_csv(path, stage, min_rows=2).columns)
+            missing = required_columns - columns
+            if missing:
+                raise PipelineValidationError(
+                    f"{stage}: clean pose CSV {path} is missing columns {sorted(missing)}"
+                )
+
+
+def _validate_complexity(layout: PipelineOutputLayout, stems: tuple[Path, ...]) -> None:
+    stage = "cumulative-complexity"
+    _require_csv(layout.temp_dir / "complexities" / "dvaj_complexity.csv", stage)
+    for stem in stems:
+        path = _expected_path(
+            layout.temp_dir / "complexities" / "byfile",
+            stem,
+            ".complexity.csv",
+        )
+        _require_csv(path, stage, min_rows=2)
+
+
+def _validate_audio(layout: PipelineOutputLayout, stems: tuple[Path, ...]) -> None:
+    stage = "audio-analysis"
+    _require_csv(layout.temp_dir / "audio_analysis" / "audio_analysis_summary.csv", stage)
+    analysis_root = layout.temp_dir / "audio_analysis" / "analysis" / "video"
+    for stem in stems:
+        result = _require_json(_expected_path(analysis_root, stem, ".json"), stage)
+        if not isinstance(result, dict):
+            raise PipelineValidationError(f"{stage}: audio result is not an object")
+        tempo_info = result.get("tempo_info")
+        if not isinstance(tempo_info, dict) or not tempo_info.get("audible_beats"):
+            raise PipelineValidationError(
+                f"{stage}: audio result is missing tempo_info.audible_beats"
+            )
+        if result.get("duration", 0) <= 0 or result.get("sample_rate", 0) <= 0:
+            raise PipelineValidationError(
+                f"{stage}: audio result has invalid duration or sample rate"
+            )
+
+
+def _validate_dancetrees(layout: PipelineOutputLayout, stems: tuple[Path, ...]) -> None:
+    stage = "add-complexity"
+    source_root = layout.temp_dir / "audio_analysis" / "dancetrees" / "video"
+    output_root = layout.temp_dir / "trees_with_complexity"
+    for stem in stems:
+        _require_json(_expected_path(source_root, stem, ".dancetree.json"), stage)
+        tree = _require_json(_expected_path(output_root, stem, ".dancetree.json"), stage)
+        if not isinstance(tree, dict) or not isinstance(tree.get("root"), dict):
+            raise PipelineValidationError(f"{stage}: invalid enriched DanceTree JSON for {stem}")
+        generation_data = tree.get("generation_data")
+        if not isinstance(generation_data, dict) or not generation_data.get("complexity"):
+            raise PipelineValidationError(
+                f"{stage}: enriched DanceTree has no complexity metadata for {stem}"
+            )
+
+
+def _validate_bundle(layout: PipelineOutputLayout) -> None:
+    stage = "bundle-data"
+    dances = _require_json(layout.bundle_export_path / "dances.json", stage)
+    dancetrees = _require_json(layout.bundle_export_path / "dancetrees.json", stage)
+    if not isinstance(dances, list):
+        raise PipelineValidationError(f"{stage}: dances.json must contain a list")
+    if not isinstance(dancetrees, dict):
+        raise PipelineValidationError(f"{stage}: dancetrees.json must contain an object")
+
+
+def validate_stage_outputs(stage: str, layout: PipelineOutputLayout) -> None:
+    """Validate the output contract for one completed pipeline stage."""
+
+    stems = layout.video_stems()
+    if not stems:
+        raise PipelineValidationError(
+            f"{stage}: no .mp4 input videos found under {layout.video_srcdir}"
+        )
+
+    validators: dict[str, t.Callable[[], None]] = {
+        "update-database": lambda: _validate_database(layout, stems),
+        "extract-pose-data": lambda: _validate_pose_outputs(layout, stems, clean=False),
+        "preprocess-pose-data": lambda: _validate_pose_outputs(layout, stems, clean=True),
+        "cumulative-complexity": lambda: _validate_complexity(layout, stems),
+        "audio-analysis": lambda: _validate_audio(layout, stems),
+        "add-complexity": lambda: _validate_dancetrees(layout, stems),
+        "bundle-data": lambda: _validate_bundle(layout),
+    }
+    try:
+        validator = validators[stage]
+    except KeyError as error:
+        raise ValueError(f"Unknown pipeline stage: {stage}") from error
+    validator()

--- a/motion-pipeline/motion_extraction/run_staged_pipeline.py
+++ b/motion-pipeline/motion_extraction/run_staged_pipeline.py
@@ -1,0 +1,134 @@
+"""Stage a Drive dataset locally and run the validated reference-video pipeline."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+import typing as t
+
+from .dancetree.run_dancetree_pipeline import run_dancetree_pipeline
+from .pipeline_validation import PipelineOutputLayout, PipelineOutputValidator
+from .rclone_transfer import pull
+
+
+def _default_run_dir() -> Path:
+    """Return a unique local output directory for one staged run."""
+
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    return Path("temp") / "rclone_pipeline_runs" / timestamp
+
+
+def run_staged_pipeline(
+    remote_path: str,
+    run_dir: Path,
+    *,
+    include_audio_in_bundle: bool = False,
+    include_thumbnail_in_bundle: bool = False,
+    rewrite_existing_holistic_data: bool = False,
+    rewrite_existing_preprocessed_pose_data: bool = False,
+    skip_existing_cumulative_complexity: bool = False,
+    skip_existing_audioanalysis: bool = False,
+) -> Path:
+    """Pull ``remote_path``, run the local pipeline, and write run metadata."""
+
+    run_dir = run_dir.resolve()
+    source_dir = run_dir / "source"
+    output_dir = run_dir / "output"
+    source_dir.mkdir(parents=True, exist_ok=True)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    print(f"Staging dataset:{remote_path} into {source_dir}")
+    pull(remote_path, source_dir)
+
+    layout = PipelineOutputLayout(
+        database_csv_path=output_dir / "db.csv",
+        video_srcdir=source_dir,
+        holistic_data_srcdir=output_dir / "holistic_data",
+        pose2d_data_srcdir=output_dir / "pose2d_data",
+        temp_dir=output_dir / "temp",
+        bundle_export_path=output_dir / "bundle" / "nonmedia",
+        bundle_media_export_path=output_dir / "bundle" / "media",
+    )
+    validator = PipelineOutputValidator(layout)
+
+    run_dancetree_pipeline(
+        database_csv_path=layout.database_csv_path,
+        video_srcdir=layout.video_srcdir,
+        holistic_data_srcdir=layout.holistic_data_srcdir,
+        pose2d_data_srcdir=layout.pose2d_data_srcdir,
+        temp_dir=layout.temp_dir,
+        bundle_export_path=layout.bundle_export_path,
+        bundle_media_export_path=layout.bundle_media_export_path,
+        include_audio_in_bundle=include_audio_in_bundle,
+        include_thumbnail_in_bundle=include_thumbnail_in_bundle,
+        rewrite_existing_holistic_data=rewrite_existing_holistic_data,
+        rewrite_existing_preprocessed_pose_data=rewrite_existing_preprocessed_pose_data,
+        skip_existing_cumulative_complexity=skip_existing_cumulative_complexity,
+        skip_existing_audioanalysis=skip_existing_audioanalysis,
+        visibility_mode="interpolate",
+        artifact_archive_root=output_dir / "artifact-archive",
+        stage_validator=validator,
+    )
+
+    metadata = {
+        "remote_path": f"dataset:{remote_path}",
+        "completed_at_utc": datetime.now(timezone.utc).isoformat(),
+        "run_directory": ".",
+        "source_directory": "source",
+        "output_directory": "output",
+        "validated_stages": validator.validated_stages,
+        "parameters": {
+            "include_audio_in_bundle": include_audio_in_bundle,
+            "include_thumbnail_in_bundle": include_thumbnail_in_bundle,
+            "rewrite_existing_holistic_data": rewrite_existing_holistic_data,
+            "rewrite_existing_preprocessed_pose_data": rewrite_existing_preprocessed_pose_data,
+            "skip_existing_cumulative_complexity": skip_existing_cumulative_complexity,
+            "skip_existing_audioanalysis": skip_existing_audioanalysis,
+        },
+    }
+    metadata_path = run_dir / "run-manifest.json"
+    metadata_path.write_text(json.dumps(metadata, indent=2) + "\n", encoding="utf-8")
+    print(f"Validated {len(validator.validated_stages)} pipeline stages")
+    print(f"Run manifest: {metadata_path}")
+    return run_dir
+
+
+def main(argv: t.Sequence[str] | None = None) -> None:
+    """Parse the staged-run CLI and execute it."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--remote-path",
+        required=True,
+        help="path below the read-only dataset rclone remote, e.g. referencevideos",
+    )
+    parser.add_argument(
+        "--run-dir",
+        type=Path,
+        default=None,
+        help="local run directory; defaults to a timestamped directory under temp/",
+    )
+    parser.add_argument("--include-audio-in-bundle", action="store_true")
+    parser.add_argument("--include-thumbnail-in-bundle", action="store_true")
+    parser.add_argument("--rewrite-existing-holistic-data", action="store_true")
+    parser.add_argument("--rewrite-existing-preprocessed-pose-data", action="store_true")
+    parser.add_argument("--skip-existing-cumulative-complexity", action="store_true")
+    parser.add_argument("--skip-existing-audioanalysis", action="store_true")
+    args = parser.parse_args(argv)
+
+    run_staged_pipeline(
+        args.remote_path,
+        args.run_dir or _default_run_dir(),
+        include_audio_in_bundle=args.include_audio_in_bundle,
+        include_thumbnail_in_bundle=args.include_thumbnail_in_bundle,
+        rewrite_existing_holistic_data=args.rewrite_existing_holistic_data,
+        rewrite_existing_preprocessed_pose_data=args.rewrite_existing_preprocessed_pose_data,
+        skip_existing_cumulative_complexity=args.skip_existing_cumulative_complexity,
+        skip_existing_audioanalysis=args.skip_existing_audioanalysis,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/motion-pipeline/motion_extraction/tests/test_pipeline_validation.py
+++ b/motion-pipeline/motion_extraction/tests/test_pipeline_validation.py
@@ -1,0 +1,230 @@
+"""Tests for staged pipeline output contracts and rclone command construction."""
+
+from __future__ import annotations
+
+import json
+import importlib
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from motion_extraction.pipeline_validation import (
+    PipelineOutputLayout,
+    PipelineOutputValidator,
+    PipelineValidationError,
+)
+from motion_extraction.rclone_transfer import pull, publish_processed_bundle
+
+
+staged_pipeline = importlib.import_module("motion_extraction.run_staged_pipeline")
+
+
+def _layout(tmp_path: Path) -> PipelineOutputLayout:
+    video_dir = tmp_path / "source"
+    video_dir.mkdir()
+    (video_dir / "lesson" / "clip.mp4").parent.mkdir()
+    (video_dir / "lesson" / "clip.mp4").write_bytes(b"video")
+    output = tmp_path / "output"
+    return PipelineOutputLayout(
+        database_csv_path=output / "db.csv",
+        video_srcdir=video_dir,
+        holistic_data_srcdir=output / "holistic_data",
+        pose2d_data_srcdir=output / "pose2d_data",
+        temp_dir=output / "temp",
+        bundle_export_path=output / "bundle" / "nonmedia",
+        bundle_media_export_path=output / "bundle" / "media",
+    )
+
+
+def _write_csv(path: Path, dataframe: pd.DataFrame) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    dataframe.to_csv(path, index=False)
+
+
+def _write_json(path: Path, value: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value), encoding="utf-8")
+
+
+def _populate_outputs(layout: PipelineOutputLayout) -> None:
+    stem = Path("lesson/clip")
+    _write_csv(
+        layout.database_csv_path,
+        pd.DataFrame({"clipRelativeStem": [stem.as_posix()], "frameCount": [10], "fps": [30]}),
+    )
+    for root, suffix in (
+        (layout.holistic_data_srcdir, ".holisticdata.raw.csv"),
+        (layout.pose2d_data_srcdir, ".pose2d.raw.csv"),
+    ):
+        _write_csv(root / f"{stem.as_posix()}{suffix}", pd.DataFrame({"frame": [0, 1]}))
+    for root, suffix in (
+        (layout.holistic_data_srcdir, ".holisticdata.clean.csv"),
+        (layout.pose2d_data_srcdir, ".pose2d.clean.csv"),
+    ):
+        _write_csv(
+            root / f"{stem.as_posix()}{suffix}",
+            pd.DataFrame(
+                {
+                    "frame": [0, 1],
+                    "preprocess_torso_length": [1.0, 1.0],
+                    "preprocess_is_usable": [1, 1],
+                }
+            ),
+        )
+    _write_csv(
+        layout.temp_dir / "complexities" / "dvaj_complexity.csv",
+        pd.DataFrame({"clip": [stem.as_posix()]}),
+    )
+    _write_csv(
+        layout.temp_dir / "complexities" / "byfile" / "lesson" / "clip.complexity.csv",
+        pd.DataFrame({"frame": [0, 1], "method": [0.0, 1.0]}),
+    )
+    _write_csv(
+        layout.temp_dir / "audio_analysis" / "audio_analysis_summary.csv",
+        pd.DataFrame({"file": [stem.as_posix()]}),
+    )
+    audio_result = {
+        "duration": 1.0,
+        "sample_rate": 44100,
+        "tempo_info": {"bpm": 120, "audible_beats": [0.0, 0.5]},
+    }
+    _write_json(
+        layout.temp_dir / "audio_analysis" / "analysis" / "video" / "lesson" / "clip.json",
+        audio_result,
+    )
+    tree = {"root": {}, "generation_data": {"complexity": "method"}}
+    _write_json(
+        layout.temp_dir / "audio_analysis" / "dancetrees" / "video" / "lesson" / "clip.dancetree.json",
+        tree,
+    )
+    _write_json(
+        layout.temp_dir / "trees_with_complexity" / "lesson" / "clip.dancetree.json",
+        tree,
+    )
+    _write_json(layout.bundle_export_path / "dances.json", [])
+    _write_json(layout.bundle_export_path / "dancetrees.json", {})
+
+
+def test_validator_checks_all_pipeline_stages(tmp_path: Path) -> None:
+    """Validate every stage against the expected local output layout."""
+
+    layout = _layout(tmp_path)
+    _populate_outputs(layout)
+    validator = PipelineOutputValidator(layout)
+
+    for stage in (
+        "update-database",
+        "extract-pose-data",
+        "preprocess-pose-data",
+        "cumulative-complexity",
+        "audio-analysis",
+        "add-complexity",
+        "bundle-data",
+    ):
+        validator(stage)
+
+    assert validator.validated_stages == [
+        "update-database",
+        "extract-pose-data",
+        "preprocess-pose-data",
+        "cumulative-complexity",
+        "audio-analysis",
+        "add-complexity",
+        "bundle-data",
+    ]
+
+
+def test_validator_reports_missing_stage_output(tmp_path: Path) -> None:
+    """Fail with the stage name and missing path when an artifact is absent."""
+
+    layout = _layout(tmp_path)
+    _populate_outputs(layout)
+    (layout.temp_dir / "trees_with_complexity" / "lesson" / "clip.dancetree.json").unlink()
+
+    with pytest.raises(PipelineValidationError, match="add-complexity"):
+        PipelineOutputValidator(layout)("add-complexity")
+
+
+def test_rclone_pull_uses_dataset_remote(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """The pull helper copies from the read-only dataset remote."""
+
+    calls: list[list[str]] = []
+
+    def fake_run(command: list[str], check: bool) -> None:
+        calls.append(command)
+        assert check is True
+
+    monkeypatch.setattr("motion_extraction.rclone_transfer.subprocess.run", fake_run)
+    destination = tmp_path / "source"
+    pull("referencevideos", destination)
+
+    assert calls == [["rclone", "copy", "dataset:referencevideos", str(destination), "--progress"]]
+    assert destination.is_dir()
+
+
+def test_rclone_processed_bundle_publication_uses_sync(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Processed-media publication is an explicit replacing sync."""
+
+    calls: list[list[str]] = []
+    monkeypatch.setattr(
+        "motion_extraction.rclone_transfer.subprocess.run",
+        lambda command, check: calls.append(command),
+    )
+    bundle = tmp_path / "media"
+    bundle.mkdir()
+    publish_processed_bundle(bundle)
+
+    assert calls == [["rclone", "sync", str(bundle), "processedmediabundle:", "--progress"]]
+
+
+def test_staged_runner_pulls_runs_and_writes_manifest(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The orchestration layer connects staging, pipeline execution, and metadata."""
+
+    def fake_pull(remote_path: str, local_path: Path) -> None:
+        assert remote_path == "referencevideos"
+        (local_path / "clip.mp4").parent.mkdir(parents=True, exist_ok=True)
+        (local_path / "clip.mp4").write_bytes(b"video")
+
+    class FakeValidator:
+        def __init__(self, layout: object) -> None:
+            self.validated_stages: list[str] = []
+
+        def __call__(self, stage: str) -> None:
+            self.validated_stages.append(stage)
+
+    def fake_pipeline(**kwargs: object) -> None:
+        validator = kwargs["stage_validator"]
+        assert callable(validator)
+        for stage in (
+            "update-database",
+            "extract-pose-data",
+            "preprocess-pose-data",
+            "cumulative-complexity",
+            "audio-analysis",
+            "add-complexity",
+            "bundle-data",
+        ):
+            validator(stage)
+
+    monkeypatch.setattr(staged_pipeline, "pull", fake_pull)
+    monkeypatch.setattr(staged_pipeline, "PipelineOutputValidator", FakeValidator)
+    monkeypatch.setattr(staged_pipeline, "run_dancetree_pipeline", fake_pipeline)
+
+    run_dir = staged_pipeline.run_staged_pipeline("referencevideos", tmp_path / "run")
+    manifest = json.loads((run_dir / "run-manifest.json").read_text(encoding="utf-8"))
+
+    assert manifest["remote_path"] == "dataset:referencevideos"
+    assert manifest["validated_stages"] == [
+        "update-database",
+        "extract-pose-data",
+        "preprocess-pose-data",
+        "cumulative-complexity",
+        "audio-analysis",
+        "add-complexity",
+        "bundle-data",
+    ]

--- a/motion-pipeline/motion_extraction/tests/test_smoke_pipeline.py
+++ b/motion-pipeline/motion_extraction/tests/test_smoke_pipeline.py
@@ -29,6 +29,7 @@ from motion_extraction.preprocess_pose_data import (
     PoseDataType,
     preprocess_all_pose_data,
 )
+from motion_extraction.pipeline_validation import PipelineOutputLayout, PipelineOutputValidator
 from motion_extraction.update_database import update_database
 
 
@@ -363,6 +364,17 @@ def test_full_pipeline_smoke(case_name: str, tmp_path: Path) -> None:
     pose2d_root = tmp_path / "pose2d_data"
     bundle_root = tmp_path / "bundle"
     media_root = tmp_path / "bundle_media"
+    validator = PipelineOutputValidator(
+        PipelineOutputLayout(
+            database_csv_path=tmp_path / "db.csv",
+            video_srcdir=input_video_path.parent,
+            holistic_data_srcdir=holistic_root,
+            pose2d_data_srcdir=pose2d_root,
+            temp_dir=temp_root,
+            bundle_export_path=bundle_root,
+            bundle_media_export_path=media_root,
+        )
+    )
 
     run_dancetree_pipeline(
         database_csv_path=tmp_path / "db.csv",
@@ -382,7 +394,18 @@ def test_full_pipeline_smoke(case_name: str, tmp_path: Path) -> None:
         suppress_audio_analysis_artifacts=True,
         suppress_add_complexity_artifacts=True,
         suppress_bundle_data_artifacts=True,
+        stage_validator=validator,
     )
+
+    assert validator.validated_stages == [
+        "update-database",
+        "extract-pose-data",
+        "preprocess-pose-data",
+        "cumulative-complexity",
+        "audio-analysis",
+        "add-complexity",
+        "bundle-data",
+    ]
 
     assert (holistic_root / f"{video_path.stem}.holisticdata.raw.csv").is_file()
     assert (pose2d_root / f"{video_path.stem}.pose2d.raw.csv").is_file()

--- a/motion-pipeline/pyproject.toml
+++ b/motion-pipeline/pyproject.toml
@@ -12,9 +12,10 @@ dependencies = [
     "dataclasses-json==0.6.7",
     "librosa==0.11.0",
     "matplotlib==3.8.0",
-    # MediaPipe 1.0.0 removed the legacy `mediapipe.solutions` API.  The
-    # pipeline uses the supported MediaPipe Tasks APIs throughout.
-    "mediapipe==1.0.0",
+    # MediaPipe 1.0.0's Holistic task graph aborts on macOS when its Metal
+    # service is unavailable, even when CPU inference is requested. The 0.10.x
+    # Tasks runtime is compatible with the current Holistic pipeline.
+    "mediapipe==0.10.21",
     "numpy==1.25.2",
     "opencv-contrib-python==4.8.1.78",
     "pandas==2.3.3",

--- a/motion-pipeline/script_invocations/publish_processed_media.sh
+++ b/motion-pipeline/script_invocations/publish_processed_media.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKSPACE_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+UV_BIN="${UV_BIN:-uv}"
+
+if [[ "${1:-}" != "--confirm" || -z "${2:-}" || -n "${3:-}" ]]; then
+    echo "Usage: $0 --confirm /absolute/path/to/verified/bundle/media" >&2
+    echo "This replaces the processedmediabundle: remote with the supplied directory." >&2
+    exit 2
+fi
+
+LOCAL_BUNDLE="$2"
+if [[ ! -d "${LOCAL_BUNDLE}" ]]; then
+    echo "Processed media directory does not exist: ${LOCAL_BUNDLE}" >&2
+    exit 1
+fi
+
+if [[ -z "$(find "${LOCAL_BUNDLE}" -type f -print -quit)" ]]; then
+    echo "Refusing to replace the remote with an empty processed media directory." >&2
+    exit 1
+fi
+
+if ! command -v "${UV_BIN}" >/dev/null 2>&1; then
+    echo "Expected uv on PATH; install it and run 'uv sync --locked --group dev' in ${WORKSPACE_DIR}." >&2
+    exit 1
+fi
+
+if ! command -v rclone >/dev/null 2>&1; then
+    echo "Expected rclone on PATH and a configured processedmediabundle remote." >&2
+    exit 1
+fi
+
+cd "${WORKSPACE_DIR}"
+exec "${UV_BIN}" run --locked python -m motion_extraction.rclone_transfer publish-processed-bundle "${LOCAL_BUNDLE}"

--- a/motion-pipeline/script_invocations/run_rclone_pipeline.sh
+++ b/motion-pipeline/script_invocations/run_rclone_pipeline.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKSPACE_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+UV_BIN="${UV_BIN:-uv}"
+
+if ! command -v "${UV_BIN}" >/dev/null 2>&1; then
+    echo "Expected uv on PATH; install it and run 'uv sync --locked --group dev' in ${WORKSPACE_DIR}." >&2
+    exit 1
+fi
+
+if ! command -v rclone >/dev/null 2>&1; then
+    echo "Expected rclone on PATH and a configured dataset remote." >&2
+    exit 1
+fi
+
+cd "${WORKSPACE_DIR}"
+exec "${UV_BIN}" run --locked python -m motion_extraction.run_staged_pipeline "$@"

--- a/motion-pipeline/uv.lock
+++ b/motion-pipeline/uv.lock
@@ -17,6 +17,15 @@ wheels = [
 ]
 
 [[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
 name = "audioread"
 version = "3.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -153,7 +162,7 @@ requires-dist = [
     { name = "dataclasses-json", specifier = "==0.6.7" },
     { name = "librosa", specifier = "==0.11.0" },
     { name = "matplotlib", specifier = "==3.8.0" },
-    { name = "mediapipe", specifier = "==1.0.0" },
+    { name = "mediapipe", specifier = "==0.10.21" },
     { name = "numpy", specifier = "==1.25.2" },
     { name = "opencv-contrib-python", specifier = "==4.8.1.78" },
     { name = "pandas", specifier = "==2.3.3" },
@@ -258,6 +267,38 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jax"
+version = "0.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jaxlib" },
+    { name = "ml-dtypes" },
+    { name = "numpy" },
+    { name = "opt-einsum" },
+    { name = "scipy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/b9/6d3d88fbab17696d00824ecac3d67feea1ff0abe12d3ebe64166a311ac04/jax-0.6.1.tar.gz", hash = "sha256:c4dcb93e1d34f80cf7adfa81f3fdab62a5068b69107b7a6117f8742ab37b6779", size = 2062260, upload-time = "2025-05-21T18:10:45.017Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/89/99805cd801919b4535e023bfe2de651f5a3ec4f5846a867cbc08006db455/jax-0.6.1-py3-none-any.whl", hash = "sha256:69a4e4506caa5466702bdfd0d7a13d1f9b7281d473885721100a3087fcabf8f9", size = 2394773, upload-time = "2025-05-21T18:10:42.835Z" },
+]
+
+[[package]]
+name = "jaxlib"
+version = "0.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ml-dtypes" },
+    { name = "numpy" },
+    { name = "scipy" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bb/75/f16efee0f23acef960c18af326d608cff2e27aefabffdc652ccec3004ff2/jaxlib-0.6.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:277cc7e9d657d0893a559261277b3eae916ad7fa73e300a629261fb537dca0f1", size = 53770292, upload-time = "2025-05-21T18:10:55.238Z" },
+    { url = "https://files.pythonhosted.org/packages/03/06/a135aa4747922bf79caf7132293f625e7921e27369bbbd24bd847c35140d/jaxlib-0.6.1-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:8106dc316eb440d07b9d4628a0c8e2acf76da5606742c9f5c33104aaa77b0ac2", size = 78686142, upload-time = "2025-05-21T18:11:00.366Z" },
+    { url = "https://files.pythonhosted.org/packages/17/c0/edc1c36586202a9ef2b0341d999cff5737e47a239e56440be650860f87f8/jaxlib-0.6.1-cp310-cp310-manylinux2014_x86_64.whl", hash = "sha256:7ae5815ada71b69532ce443a11160a3ed25c67e82a294a0d89af9d4d27429434", size = 89047535, upload-time = "2025-05-21T18:11:05.534Z" },
+    { url = "https://files.pythonhosted.org/packages/43/2e/b9303b425efe12c144e9eb0a9aa59978020fecf20c1591f09e3181610680/jaxlib-0.6.1-cp310-cp310-win_amd64.whl", hash = "sha256:3301addee156f55d1f8079f80b314d89b80094740b7d64e5ec6e7ef2e1febbd7", size = 56824544, upload-time = "2025-05-21T18:11:09.857Z" },
 ]
 
 [[package]]
@@ -406,23 +447,41 @@ wheels = [
 
 [[package]]
 name = "mediapipe"
-version = "1.0.0"
+version = "0.10.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "absl-py" },
-    { name = "certifi" },
+    { name = "attrs" },
     { name = "flatbuffers" },
+    { name = "jax" },
+    { name = "jaxlib" },
     { name = "matplotlib" },
     { name = "numpy" },
     { name = "opencv-contrib-python" },
+    { name = "protobuf" },
+    { name = "sentencepiece" },
     { name = "sounddevice" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/d7/3a5dfaa86128db110c62a4d0f0c948304817932c9dd3257313bbdf24f7d5/mediapipe-1.0.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:7ee4783be41b2de345e1eb71e2f7e7c159a50ed5c283e60ccb8f5a6027c70a82", size = 32986466, upload-time = "2026-07-27T21:02:15.631Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/e0/960e9761ac183990cd604265ee16542f08334ad5a6853ff6663cc4556196/mediapipe-1.0.0-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:e57d9a606723b2c77a51bb1d194c8eb736a84c552d24578a8536f47f656bb241", size = 34454205, upload-time = "2026-07-27T21:02:18.868Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/1d/bc666b2edee87cc06421b040df0282607339091954ab9d4906a65a45be10/mediapipe-1.0.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:07a449446bf888a8a2787dbf6fc1a33da4c47977313deec64d13c35bff41f6d2", size = 36467250, upload-time = "2026-07-27T21:02:21.732Z" },
-    { url = "https://files.pythonhosted.org/packages/68/53/ffb67e668f23130aff197ec49be912be910c128b60658000d8bf263207c9/mediapipe-1.0.0-py3-none-win_amd64.whl", hash = "sha256:da57e6719bbab05007272c91d6ca2e0e2e370709491cbe344a372f87e25cf604", size = 16057095, upload-time = "2026-07-27T21:02:24.647Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/39/1513febb6c922e0813b93bbdde5289f32c49f4bd4bf768bc199e91285299/mediapipe-1.0.0-py3-none-win_arm64.whl", hash = "sha256:01260f58fedd2cbebe69f4d4fcbc6327aba17090e19ef6a03c7afda084cd64e1", size = 14056470, upload-time = "2026-07-27T21:02:26.959Z" },
+    { url = "https://files.pythonhosted.org/packages/66/85/5be11ee221b04cd1496131222199ad6469bd49e377157b84b0895325afb2/mediapipe-0.10.21-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:b7cf0756f38f81b6d1cbc77bf78aeba53e4c99270a400388fdecabc3350264d8", size = 49161075, upload-time = "2025-02-06T19:06:01.165Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/cc/5a7b367f444b7524d907209af796b3be46d35a90f53ee40ee614b03c7a5b/mediapipe-0.10.21-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:1861f24bd64fbec87364e4d1ea1c4a648d94a8cafbd2def249039c03bd63c0be", size = 49069365, upload-time = "2025-02-06T19:06:10.207Z" },
+    { url = "https://files.pythonhosted.org/packages/41/9f/838762bcfd3236d66e196b8c076c8bd26d749b9c52947a6b9201be034668/mediapipe-0.10.21-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:b838d2fc85e7b17e7dd3ceabf2d5b832f6834438c8065506cd2d4ef0aa9f83cc", size = 35622771, upload-time = "2025-02-06T19:06:16.206Z" },
+    { url = "https://files.pythonhosted.org/packages/de/88/aa7fd24beb9d47283fdc271032c749be795c0cfe98eee13f624d6e1b15f4/mediapipe-0.10.21-cp310-cp310-win_amd64.whl", hash = "sha256:05cf8b57130c723f12ecb8273fea79038e86775925659cdfe61674627b9da65e", size = 50965067, upload-time = "2025-02-06T19:06:24.419Z" },
+]
+
+[[package]]
+name = "ml-dtypes"
+version = "0.5.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/4a/c27b42ed9b1c7d13d9ba8b6905dece787d6259152f2309338aed29b2447b/ml_dtypes-0.5.4.tar.gz", hash = "sha256:8ab06a50fb9bf9666dd0fe5dfb4676fa2b0ac0f31ecff72a6c3af8e22c063453", size = 692314, upload-time = "2025-11-17T22:32:31.031Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/3a/c5b855752a70267ff729c349e650263adb3c206c29d28cc8ea7ace30a1d5/ml_dtypes-0.5.4-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:b95e97e470fe60ed493fd9ae3911d8da4ebac16bd21f87ffa2b7c588bf22ea2c", size = 679735, upload-time = "2025-11-17T22:31:31.367Z" },
+    { url = "https://files.pythonhosted.org/packages/41/79/7433f30ee04bd4faa303844048f55e1eb939131c8e5195a00a96a0939b64/ml_dtypes-0.5.4-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b4b801ebe0b477be666696bda493a9be8356f1f0057a57f1e35cd26928823e5a", size = 5051883, upload-time = "2025-11-17T22:31:33.658Z" },
+    { url = "https://files.pythonhosted.org/packages/10/b1/8938e8830b0ee2e167fc75a094dea766a1152bde46752cd9bfc57ee78a82/ml_dtypes-0.5.4-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:388d399a2152dd79a3f0456a952284a99ee5c93d3e2f8dfe25977511e0515270", size = 5030369, upload-time = "2025-11-17T22:31:35.595Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/a3/51886727bd16e2f47587997b802dd56398692ce8c6c03c2e5bb32ecafe26/ml_dtypes-0.5.4-cp310-cp310-win_amd64.whl", hash = "sha256:4ff7f3e7ca2972e7de850e7b8fcbb355304271e2933dd90814c1cb847414d6e2", size = 210738, upload-time = "2025-11-17T22:31:37.43Z" },
 ]
 
 [[package]]
@@ -498,6 +557,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/32/9e/4dcc0bb70e3b365dc85b8f96c63e6a306653f7cc6ed061aa6cc7b2bddee7/opencv_contrib_python-4.8.1.78-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3fb62bc5967a79bce7c576ef94dea0b9172e52bab91630103e042cb5f29a148a", size = 67807199, upload-time = "2023-09-28T11:02:11.339Z" },
     { url = "https://files.pythonhosted.org/packages/cd/bf/5880ce389a9d47fc96d52280f8ce3f69fbd0388662819fbcdf6fd829719f/opencv_contrib_python-4.8.1.78-cp37-abi3-win32.whl", hash = "sha256:f8737cf3055a6156c66c75432ed28ee3c1d52532b17d91ed73d508ae351b3e66", size = 34070000, upload-time = "2023-09-28T11:02:19.682Z" },
     { url = "https://files.pythonhosted.org/packages/81/3c/bbb3ceee9fbefc505f98c24dafda68c7b3c4f83b6951c0712b4623fe4cce/opencv_contrib_python-4.8.1.78-cp37-abi3-win_amd64.whl", hash = "sha256:377936b02dcf82dc70261101381a8ad82b03d1298f185886be298d74fe35c328", size = 44790515, upload-time = "2023-09-28T11:02:28.069Z" },
+]
+
+[[package]]
+name = "opt-einsum"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/b9/2ac072041e899a52f20cf9510850ff58295003aa75525e58343591b0cbfb/opt_einsum-3.4.0.tar.gz", hash = "sha256:96ca72f1b886d148241348783498194c577fa30a8faac108586b14f1ba4473ac", size = 63004, upload-time = "2024-09-26T14:33:24.483Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/23/cd/066e86230ae37ed0be70aae89aabf03ca8d9f39c8aea0dec8029455b5540/opt_einsum-3.4.0-py3-none-any.whl", hash = "sha256:69bb92469f86a1565195ece4ac0323943e83477171b91d24c35afe028a90d7cd", size = 71932, upload-time = "2024-09-26T14:33:23.039Z" },
 ]
 
 [[package]]
@@ -748,6 +816,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/25/e1/3df8f83cb15f3500478c889be8fb18700813b95e9e087328230b98d547ff/scipy-1.15.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:ed7284b21a7a0c8f1b6e5977ac05396c0d008b89e05498c8b7e8f4a1423bba0e", size = 37238749, upload-time = "2025-05-08T16:04:55.215Z" },
     { url = "https://files.pythonhosted.org/packages/93/3e/b3257cf446f2a3533ed7809757039016b74cd6f38271de91682aa844cfc5/scipy-1.15.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:5380741e53df2c566f4d234b100a484b420af85deb39ea35a1cc1be84ff53a5c", size = 40022383, upload-time = "2025-05-08T16:05:01.914Z" },
     { url = "https://files.pythonhosted.org/packages/d1/84/55bc4881973d3f79b479a5a2e2df61c8c9a04fcb986a213ac9c02cfb659b/scipy-1.15.3-cp310-cp310-win_amd64.whl", hash = "sha256:9d61e97b186a57350f6d6fd72640f9e99d5a4a2b8fbf4b9ee9a841eab327dc13", size = 41259201, upload-time = "2025-05-08T16:05:08.166Z" },
+]
+
+[[package]]
+name = "sentencepiece"
+version = "0.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/33/ea3cb3839607eb175da835244a798f797f478c5ddf0e8ecdf57ea85a4c70/sentencepiece-0.2.2.tar.gz", hash = "sha256:3d2b5e824b5622038dc7b490897efe05ebbbb9e7350fc142f3ecc8789ef9bdf6", size = 8218435, upload-time = "2026-07-12T08:39:34.701Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/1b/e6c69e4c2026ed575d68dda2847a404468ca7b5fa684bb0b19f71d82d29d/sentencepiece-0.2.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:bc7b0b1da20f856bfac5f84b2673fe534b167e41980b27442ca8f78c2b7eb77e", size = 2180607, upload-time = "2026-07-12T08:38:01.018Z" },
+    { url = "https://files.pythonhosted.org/packages/36/5a/2a1d84c87dc075d4f8cf1a2470a95399e59834e219ffb5f4285533e750d0/sentencepiece-0.2.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:8b2db2056c97224e122054fd794543cde5d24b7cae28424f6e3eb79bbe08e42b", size = 1437502, upload-time = "2026-07-12T08:38:02.899Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/39/3d43a75dd5a22503ca5074d0d37707cabb2e4a71b4bc6e6c61be3643cc7a/sentencepiece-0.2.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8f1f61592e7cabd45d49ce8cc0ef42ca655c091e037153754fb3fa59725b5914", size = 1345667, upload-time = "2026-07-12T08:38:04.657Z" },
+    { url = "https://files.pythonhosted.org/packages/90/d5/a69a8cc896e7de3fe2061b08c2f33e28656f243bed8af6a2df9f5d8c3124/sentencepiece-0.2.2-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c798f0b327bac10dc95cdac77b9a197ab2bd7dd1e60ebd7586a12d918d4be711", size = 1322864, upload-time = "2026-07-12T08:38:06.49Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/79/dd1836df32971d4eb14ff5cb4a8b3fe4419adbeada8e81d09dc53c5c0ef0/sentencepiece-0.2.2-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:44284adc6fbe9d5bdd480541431a3d93f674fa44736714d3ad4bcee8283ace7d", size = 1392757, upload-time = "2026-07-12T08:38:08.559Z" },
+    { url = "https://files.pythonhosted.org/packages/26/83/c3547715c29b7e4c84a180a240267f7685dde6f9b981396f16b95405ec9d/sentencepiece-0.2.2-cp310-cp310-win_amd64.whl", hash = "sha256:1120e0791540615e650b2e9bea835bf38a7362455d8ab62dee7968219c2d79a0", size = 1245044, upload-time = "2026-07-12T08:38:10.21Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/55/7da03b35582a4eb276f99051109f3e3e8f176835b6d6837422e4c3a013dd/sentencepiece-0.2.2-cp310-cp310-win_arm64.whl", hash = "sha256:524e2a85c028a0d2f9935191fa751e5ef9d9bcc39616f70ab14b28d0369c9936", size = 1190467, upload-time = "2026-07-12T08:38:12.07Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What changed

- Added an rclone-backed runner that stages dataset files locally and runs the DanceTree pipeline.
- Added validation after each of the seven pipeline stages.
- Added run manifests recording source paths, parameters, and validated stages.
- Added guarded processed-media publication via rclone.
- Added orchestration, validation, and rclone tests.
- Pinned MediaPipe to Tasks-compatible `0.10.21`.
- Fixed macOS Holistic extraction and documented GPU compatibility findings.

## Why

MediaPipe 1.0.0 could abort natively on macOS when its Metal service was unavailable. MediaPipe 0.10.21 completes the batch workflow while retaining Tasks API compatibility.

GPU/Metal was tested separately but is not enabled by default because Holistic detection aborts on empty landmark packets.

## Validation

- Full smoke gate: 11 passed
- Added validation tests: 5 passed
- Non-smoke suite: 24 passed
- `uv lock --check` passed
- Shell syntax checks passed
- `git diff --check` passed

## Safety

Processed-media publication is separate from pipeline execution and requires explicit `--confirm`. It was not run.